### PR TITLE
Remove duplicated "Phase 2 Phase 2" text

### DIFF
--- a/src/pages/Landing/Phases/index.tsx
+++ b/src/pages/Landing/Phases/index.tsx
@@ -92,7 +92,7 @@ export const Phases = (): JSX.Element => {
               </Text>
               <Text className="mt20">
                 <PhaseTitle>Phase 1 </PhaseTitle>
-                adds more data capacity to eth2.
+                adds data capacity to eth2.
               </Text>
               <Text className="mt20">
                 <PhaseTitle>Phase 2 </PhaseTitle>

--- a/src/pages/Landing/Phases/index.tsx
+++ b/src/pages/Landing/Phases/index.tsx
@@ -92,12 +92,11 @@ export const Phases = (): JSX.Element => {
               </Text>
               <Text className="mt20">
                 <PhaseTitle>Phase 1 </PhaseTitle>
-                handles adding and storing the data associated with eth2.
+                adds more data capacity to eth2.
               </Text>
               <Text className="mt20">
                 <PhaseTitle>Phase 2 </PhaseTitle>
-                Phase 2 adds execution to eth2 which enables programmes to be
-                run on top of it.
+                allows smart contract programs to be built and run on eth2.
               </Text>
             </ScrollAnimation>
           </div>


### PR DESCRIPTION
There was a double "Phase 2 Phase 2" in the text.  Took the opportunity to improve the descriptions.