### PR TITLE
Update instructions for CLI changes

### DIFF
--- a/src/pages/GenerateKeys/LinuxInstructions.tsx
+++ b/src/pages/GenerateKeys/LinuxInstructions.tsx
@@ -26,7 +26,8 @@ export const LinuxInstructions = ({ validatorCount }: Props) => {
     'git clone https://github.com/ethereum/eth2.0-deposit-cli.git',
     'cd eth2.0-deposit-cli',
     'pip3 install -r requirements.txt',
-    `python3 src/deposit.py ${
+    'python3 setup.py install',
+    `python3 cli/deposit.py ${
       validatorCount > 0 ? `--num_validators ${validatorCount}` : ''
     }`,
   ];

--- a/src/pages/GenerateKeys/MacInstructions.tsx
+++ b/src/pages/GenerateKeys/MacInstructions.tsx
@@ -25,7 +25,8 @@ export const MacInstructions = ({ validatorCount }: Props) => {
     'git clone https://github.com/ethereum/eth2.0-deposit-cli.git',
     'cd eth2.0-deposit-cli',
     'pip3 install -r requirements.txt',
-    `python3 src/deposit.py ${
+    'python3 setup.py install',
+    `python3 cli/deposit.py ${
       validatorCount > 0 ? `--num_validators ${validatorCount}` : ''
     }`,
   ];


### PR DESCRIPTION
Fixes #60 by updating the instructions for the CLI changes. 

- adds in additional step running `setup.py`
- changes from `src/deposit.py` to `cli/deposit.py`

This is a temporary fix to allow early users to complete the current flow. When further changes to the CLI are made we can update these instructions and update #64 