### PR TITLE
Update price per validator to 32, cleanup related usages

### DIFF
--- a/src/pages/Acknowledgements/pageContent.tsx
+++ b/src/pages/Acknowledgements/pageContent.tsx
@@ -40,9 +40,9 @@ export const pageContent = {
     title: 'Signing up',
     content: (
       <Text size="large" className="my10">
-        To become a validator on eth2, you need to deposit 
-        {PRICE_PER_VALIDATOR}
-        ETH per validator that you wish to run. This process cannot be reversed.
+        To become a validator on Ethereum 2, you need to deposit{' '}
+        {PRICE_PER_VALIDATOR} ETH per validator that you wish to run. This
+        process cannot be reversed.
       </Text>
     ),
     acknowledgementText: `I understand that I need to deposit ${PRICE_PER_VALIDATOR} ETH to sign up as a validator. And that the transfer of ETH from eth1 to to eth2 is one-way, and non-reversible.`,
@@ -90,8 +90,8 @@ export const pageContent = {
     title: 'Backup Mnemonic',
     content: (
       <Text size="large" className="my10">
-        Validator keys are derived from a unique mnemonic (or seed). Your
-        seed is the ONLY WAY to withdraw your funds. Above all, keep it safe!
+        Validator keys are derived from a unique mnemonic (or seed). Your seed
+        is the ONLY WAY to withdraw your funds. Above all, keep it safe!
       </Text>
     ),
     acknowledgementText:

--- a/src/pages/Acknowledgements/pageContent.tsx
+++ b/src/pages/Acknowledgements/pageContent.tsx
@@ -40,7 +40,7 @@ export const pageContent = {
     title: 'Signing up',
     content: (
       <Text size="large" className="my10">
-        To become a validator on Ethereum 2, you need to deposit{' '}
+        To become an eth2 validator, you need to deposit{' '}
         {PRICE_PER_VALIDATOR} ETH per validator that you wish to run. This
         process cannot be reversed.
       </Text>

--- a/src/pages/GenerateKeys/index.tsx
+++ b/src/pages/GenerateKeys/index.tsx
@@ -115,7 +115,6 @@ const _GenerateKeysPage = ({
                 ? validatorCount
                 : new BigNumber(validatorCount)
                     .times(new BigNumber(PRICE_PER_VALIDATOR))
-                    .toFixed(1)
                     .toString()}{' '}
               ETH
             </Text>
@@ -139,9 +138,9 @@ const _GenerateKeysPage = ({
           5. Save the key files and get the validator file ready
         </Heading>
         <Text className="mt20">
-          You should now have your mnemonic written down in a safe place
-          and a keystore saved for each of your {validatorCount} validators.
-          Please make sure you keep these safe, preferably offline. Your validator
+          You should now have your mnemonic written down in a safe place and a
+          keystore saved for each of your {validatorCount} validators. Please
+          make sure you keep these safe, preferably offline. Your validator
           keystores should be available in the
           <Highlight>validator_keys</Highlight> directory.
         </Text>

--- a/src/pages/Summary/index.tsx
+++ b/src/pages/Summary/index.tsx
@@ -95,8 +95,7 @@ const _SummaryPage = ({
           <Container className="mx20">
             <Text>Total Amount Required</Text>
             <InfoBox>
-              {amountValidators.times(convertedPrice).toString()}
-              ETH
+              {`${amountValidators.times(convertedPrice).toString()} ETH`}
             </InfoBox>
           </Container>
         </Box>

--- a/src/utils/envVars.ts
+++ b/src/utils/envVars.ts
@@ -13,5 +13,5 @@ export const ALETHIO_URL = 'https://explorer.goerli.aleth.io/tx';
 export const ETHERSCAN_URL = 'https://goerli.etherscan.io/tx';
 export const CONTRACT_ADDRESS = '0x4DC8B546b93131309c82505a6fdfB978D311bf45';
 export const MAINNET_ETH_REQUIREMENT = 524288;
-export const PRICE_PER_VALIDATOR = 3.2;
+export const PRICE_PER_VALIDATOR = 32;
 export const IS_MAINNET = false;


### PR DESCRIPTION
- Updates `PRICE_PER_VALIDATOR` from 3.2 to 32
- Cleans up usages using `PRICE_PER_VALIDATOR`


We should deploy a new test Deposit Contract that reflects 32ETH per validator and update the `CONTRACT_ADDRESS` in this PR before merging

Fixes #34  
