### PR TITLE
Update the instruction commands: use deposit script

### DIFF
--- a/src/pages/GenerateKeys/LinuxInstructions.tsx
+++ b/src/pages/GenerateKeys/LinuxInstructions.tsx
@@ -25,9 +25,8 @@ export const LinuxInstructions = ({ validatorCount }: Props) => {
   const terminalCommands = [
     'git clone https://github.com/ethereum/eth2.0-deposit-cli.git',
     'cd eth2.0-deposit-cli',
-    'pip3 install -r requirements.txt',
-    'python3 setup.py install',
-    `python3 cli/deposit.py ${
+    './deposit.sh install',
+    `./deposit.sh ${
       validatorCount > 0 ? `--num_validators ${validatorCount}` : ''
     }`,
   ];
@@ -40,7 +39,7 @@ export const LinuxInstructions = ({ validatorCount }: Props) => {
         </Heading>
         <Section>
           <Heading level={4} size="small" color="blueMedium" className="mb10">
-            Install python3
+            Install python3.7+
           </Heading>
           <Text>
             The python3 install process may differ depending on your linux

--- a/src/pages/GenerateKeys/MacInstructions.tsx
+++ b/src/pages/GenerateKeys/MacInstructions.tsx
@@ -24,9 +24,8 @@ export const MacInstructions = ({ validatorCount }: Props) => {
   const terminalCommands = [
     'git clone https://github.com/ethereum/eth2.0-deposit-cli.git',
     'cd eth2.0-deposit-cli',
-    'pip3 install -r requirements.txt',
-    'python3 setup.py install',
-    `python3 cli/deposit.py ${
+    './deposit.sh install',
+    `./deposit.sh ${
       validatorCount > 0 ? `--num_validators ${validatorCount}` : ''
     }`,
   ];
@@ -39,7 +38,7 @@ export const MacInstructions = ({ validatorCount }: Props) => {
         </Heading>
         <Section>
           <Heading level={4} size="small" color="blueMedium" className="mb10">
-            Install python3
+            Install python3.7+
           </Heading>
           <Text>
             You can install python3 on your MacOS device using{' '}

--- a/src/pages/GenerateKeys/WindowsInstructions.tsx
+++ b/src/pages/GenerateKeys/WindowsInstructions.tsx
@@ -24,9 +24,8 @@ export const WindowsInstructions = ({ validatorCount }: Props) => {
   const terminalCommands = [
     'git clone https://github.com/ethereum/eth2.0-deposit-cli.git',
     'cd eth2.0-deposit-cli',
-    'pip3 install -r requirements.txt',
-    'python setup.py install',
-    `python cli/deposit.py ${
+    'sh deposit.sh',
+    `sh deposit.sh ${
       validatorCount > 0 ? `--num_validators ${validatorCount}` : ''
     }`,
   ];
@@ -39,7 +38,7 @@ export const WindowsInstructions = ({ validatorCount }: Props) => {
         </Heading>
         <Section>
           <Heading level={4} size="small" color="blueMedium" className="mb10">
-            Install python3
+            Install python3.7+
           </Heading>
           <Text>
             Download python3 from{' '}


### PR DESCRIPTION
### Issue

Pending on https://github.com/ethereum/eth2.0-deposit-cli/pull/19. We can use the same script for all OSs.

### How did I fix it

1. Update the commands.
2. Note that `deposit-cli` requires python3.7+.