### PR TITLE
Update BLS to v2 with H2C v7

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
-    "@chainsafe/bls": "^1.0.0",
+    "@chainsafe/bls": "^2.0.0",
     "@ethersproject/providers": "^5.0.0-beta.151",
     "@ethersproject/units": "^5.0.0-beta.132",
     "@types/react-animate-on-scroll": "^2.1.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -967,28 +967,21 @@
     bip39 "^3.0.2"
     buffer "^5.4.3"
 
-"@chainsafe/bls@^1.0.0":
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/@chainsafe/bls/-/bls-1.0.0.tgz#1db8d26b14e8b27c6b6deba7c94342629588e263"
-  integrity sha512-IBQK77Hr0RsvxC/KfOLsuR7fv5IZwiLcUUv4l39AQUnclckewoBEzzV1dExQtLuFrm+JOWJ2OAulAsg6vuS41Q==
+"@chainsafe/bls@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@chainsafe/bls/-/bls-2.0.0.tgz#d0e59b890f543d975b637423940397ade7e4581a"
+  integrity sha512-Hb8lsiI9ydPxc1vDhBkM1Mawn0b0WKV3JeDoXXKNKx7ERlSNuEi1EfCIabCQN53ANaotqJmjTosnrD8VyWsqxQ==
   dependencies:
     "@chainsafe/bls-keygen" "^0.0.2"
-    "@chainsafe/eth2-bls-wasm" "^0.4.0"
+    "@chainsafe/eth2-bls-wasm" "^0.5.0"
     assert "^1.4.1"
-  optionalDependencies:
-    "@chainsafe/eth2-spec-tests" "^0.10.1-fix"
 
-"@chainsafe/eth2-bls-wasm@^0.4.0":
-  version "0.4.0"
-  resolved "https://registry.yarnpkg.com/@chainsafe/eth2-bls-wasm/-/eth2-bls-wasm-0.4.0.tgz#94e89e4e53ec6cdcc07178dbfeb0b80215550d2f"
-  integrity sha512-4BGktOKmUyyYJNCio5Zn1LdxaGWLhPqdUoZXokrfCLW3SKhw4E6MlnpAHwPtvnDuGSkmdF/GLhYeyjQYTtovqg==
+"@chainsafe/eth2-bls-wasm@^0.5.0":
+  version "0.5.0"
+  resolved "https://registry.yarnpkg.com/@chainsafe/eth2-bls-wasm/-/eth2-bls-wasm-0.5.0.tgz#45d0cb8807b569537d1e0099922a9617e0410b3a"
+  integrity sha512-7aHphmg504W4YTvAEvGscODrr1Fo5Mf9NxB72fuFv2BKUS/0BPgkoxG9tA+KxcFQq1hs/VUeLhq6qVdI5WfNNA==
   dependencies:
     buffer "^5.4.3"
-
-"@chainsafe/eth2-spec-tests@^0.10.1-fix":
-  version "0.10.1-fix"
-  resolved "https://registry.yarnpkg.com/@chainsafe/eth2-spec-tests/-/eth2-spec-tests-0.10.1-fix.tgz#c0fb839b5b93fae0a7cd247fd686d2a9ea926240"
-  integrity sha512-mnfIDUFZ/IsAHmJQ7hkZ3t3s7rxrr5olLz3pH1RS2kWsuQonAKzVOZTQNkHYowpeI4ebYo8H+NPRtD5mkbTTzg==
 
 "@cnakazawa/watch@^1.0.3":
   version "1.0.4"
@@ -11888,7 +11881,7 @@ querystringify@^2.1.1:
   resolved "https://registry.yarnpkg.com/querystringify/-/querystringify-2.1.1.tgz#60e5a5fd64a7f8bfa4d2ab2ed6fdf4c85bad154e"
   integrity sha512-w7fLxIRCRT7U8Qu53jQnJyPkYZIaR4n5151KMfcJlO/A9397Wxb1amJvROTK6TOnp7PfoAmg/qXiNHI+08jRfA==
 
-raf@^3.4.0, raf@^3.4.1:
+raf@^3.4.1:
   version "3.4.1"
   resolved "https://registry.yarnpkg.com/raf/-/raf-3.4.1.tgz#0742e99a4a6552f445d73e3ee0328af0ff1ede39"
   integrity sha512-Sq4CW4QhwOHE8ucn6J34MqtZCeWFP2aQSmrlroYgqAV1PjStIhJXxYuTgUIfkEk7zTLjmIjLmU5q+fbD1NnOJA==
@@ -14101,14 +14094,6 @@ typescript@^3.8.3:
   version "3.8.3"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.8.3.tgz#409eb8544ea0335711205869ec458ab109ee1061"
   integrity sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w==
-
-typewriter-effect@^2.13.0:
-  version "2.13.0"
-  resolved "https://registry.yarnpkg.com/typewriter-effect/-/typewriter-effect-2.13.0.tgz#75ce6293bc4262172e48d060d25873c4f24e0e29"
-  integrity sha512-N6yCSCbZDiZaqdsnaYUpdY4HPSg+Bpp+kbnAnRT4hWo3roHqULGTeWkghxgil5WnISbpMzfG5KKs581dWY+Odg==
-  dependencies:
-    prop-types "^15.6.2"
-    raf "^3.4.0"
 
 ua-parser-js@^0.7.18:
   version "0.7.21"


### PR DESCRIPTION
As per the final version of BLS Eth2 is going to use ([Eth2 spec v0.12](https://github.com/ethereum/eth2.0-specs/releases/tag/v0.12.0)). This PR updates BLS to the new Herumi version (via chainsafe package) thereby supporting [BLS v2](https://tools.ietf.org/html/draft-irtf-cfrg-bls-signature-02) and [Hash-to-curve v7](https://tools.ietf.org/html/draft-irtf-cfrg-hash-to-curve-07)