### PR TITLE
Verifies SSZ encoding with @chainsafe/ssz

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -7,6 +7,7 @@ module.exports = {
   globals: {
     Atomics: 'readonly',
     SharedArrayBuffer: 'readonly',
+    BigInt: true,
   },
   parser: '@typescript-eslint/parser',
   parserOptions: {

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "dependencies": {
     "@chainsafe/bls": "^1.0.0",
+    "@chainsafe/ssz": "^0.6.4",
     "@ethersproject/providers": "^5.0.0-beta.151",
     "@ethersproject/units": "^5.0.0-beta.132",
     "@types/react-animate-on-scroll": "^2.1.2",

--- a/src/pages/Transactions/transactionUtils.tsx
+++ b/src/pages/Transactions/transactionUtils.tsx
@@ -47,7 +47,7 @@ export const handleTransaction = async (
     // eslint-disable-next-line camelcase
     withdrawal_credentials,
     // eslint-disable-next-line camelcase
-    signed_deposit_data_root,
+    deposit_data_root,
   } = depositFile;
 
   try {
@@ -66,7 +66,7 @@ export const handleTransaction = async (
         prefix0X(pubkey),
         prefix0X(withdrawal_credentials),
         prefix0X(signature),
-        prefix0X(signed_deposit_data_root)
+        prefix0X(deposit_data_root)
       )
       .send(transactionParameters)
       .on('transactionHash', (txHash: string): void => {

--- a/src/pages/UploadValidator/validateDepositKey.ts
+++ b/src/pages/UploadValidator/validateDepositKey.ts
@@ -4,7 +4,48 @@
 import _every from 'lodash/every';
 import { initBLS } from '@chainsafe/bls';
 import { verifySignature } from '../../utils/verifySignature';
+import { verifyDepositRoots } from '../../utils/SSZ';
 import { DepositKeyInterface } from '../../store/reducers';
+
+const validateFieldFormatting = (
+  depositDatum: DepositKeyInterface
+): boolean => {
+  // check existence of required keys
+  if (
+    !depositDatum.pubkey ||
+    !depositDatum.withdrawal_credentials ||
+    !depositDatum.amount ||
+    !depositDatum.signature ||
+    !depositDatum.deposit_message_root ||
+    !depositDatum.deposit_data_root
+  ) {
+    return false;
+  }
+
+  // check type of values
+  if (
+    typeof depositDatum.pubkey !== 'string' ||
+    typeof depositDatum.withdrawal_credentials !== 'string' ||
+    typeof depositDatum.amount !== 'number' ||
+    typeof depositDatum.signature !== 'string' ||
+    typeof depositDatum.deposit_message_root !== 'string' ||
+    typeof depositDatum.deposit_data_root !== 'string'
+  ) {
+    return false;
+  }
+
+  // check length of strings
+  if (
+    depositDatum.pubkey.length !== 96 ||
+    depositDatum.withdrawal_credentials.length !== 64 ||
+    depositDatum.signature.length !== 192 ||
+    depositDatum.deposit_message_root.length !== 64 ||
+    depositDatum.deposit_data_root.length !== 64
+  ) {
+    return false;
+  }
+  return true;
+};
 
 export const validateDepositKey = async (
   files: DepositKeyInterface[]
@@ -14,49 +55,14 @@ export const validateDepositKey = async (
   if (!Array.isArray(files)) return false;
   if (files.length <= 0) return false;
 
-  const depositKeysStatuses: boolean[] = files.map(file => {
-    const {
-      pubkey,
-      withdrawal_credentials,
-      amount,
-      signature,
-      deposit_data_root,
-    } = file;
-
-    // check existence of required keys
-    if (
-      !pubkey ||
-      !withdrawal_credentials ||
-      !amount ||
-      !signature ||
-      !deposit_data_root
-    ) {
+  const depositKeysStatuses: boolean[] = files.map(depositDatum => {
+    if (!validateFieldFormatting(depositDatum)) {
       return false;
     }
-
-    // check type of values
-    if (
-      typeof pubkey !== 'string' ||
-      typeof withdrawal_credentials !== 'string' ||
-      typeof amount !== 'number' ||
-      typeof signature !== 'string' ||
-      typeof deposit_data_root !== 'string'
-    ) {
+    if (!verifyDepositRoots(depositDatum)) {
       return false;
     }
-
-    // check length of strings
-    if (
-      pubkey.length !== 96 ||
-      withdrawal_credentials.length !== 64 ||
-      signature.length !== 192 ||
-      deposit_data_root.length !== 64
-    ) {
-      return false;
-    }
-
-    // perform BLS check
-    return verifySignature(pubkey, signature, deposit_data_root);
+    return verifySignature(depositDatum);
   });
   return _every(depositKeysStatuses);
 };

--- a/src/store/reducers/depositFileReducer.ts
+++ b/src/store/reducers/depositFileReducer.ts
@@ -10,8 +10,8 @@ export interface DepositKeyInterface {
   withdrawal_credentials: string;
   amount: number;
   signature: string;
+  deposit_message_root: string;
   deposit_data_root: string;
-  signed_deposit_data_root: string;
   transactionStatus: TransactionStatus;
   txHash?: string;
 }

--- a/src/utils/SSZ.ts
+++ b/src/utils/SSZ.ts
@@ -1,0 +1,113 @@
+import {
+  BigIntUintType,
+  ByteVector,
+  ByteVectorType,
+  ContainerType,
+} from '@chainsafe/ssz';
+import { DepositKeyInterface } from '../store/reducers';
+
+export const bufferHex = (x: string): Buffer => Buffer.from(x, 'hex');
+
+const DepositMessage = new ContainerType({
+  fields: {
+    pubkey: new ByteVectorType({
+      length: 48,
+    }),
+    withdrawalCredentials: new ByteVectorType({
+      length: 32,
+    }),
+    amount: new BigIntUintType({
+      byteLength: 8,
+    }),
+  },
+});
+
+interface DepositMessage {
+  pubkey: ByteVector;
+  withdrawalCredentials: ByteVector;
+  amount: BigInt;
+}
+
+const DepositData = new ContainerType({
+  fields: {
+    pubkey: new ByteVectorType({
+      length: 48,
+    }),
+    withdrawalCredentials: new ByteVectorType({
+      length: 32,
+    }),
+    amount: new BigIntUintType({
+      byteLength: 8,
+    }),
+    signature: new ByteVectorType({
+      length: 96,
+    }),
+  },
+});
+
+interface DepositData {
+  pubkey: ByteVector;
+  withdrawalCredentials: ByteVector;
+  amount: BigInt;
+  signature: ByteVector;
+}
+
+export const verifyDepositRoots = (
+  depositDatum: DepositKeyInterface
+): boolean => {
+  const depositMessage: DepositMessage = {
+    pubkey: bufferHex(depositDatum.pubkey),
+    withdrawalCredentials: bufferHex(depositDatum.withdrawal_credentials),
+    amount: BigInt(depositDatum.amount),
+  };
+  const depositData: DepositData = {
+    pubkey: bufferHex(depositDatum.pubkey),
+    withdrawalCredentials: bufferHex(depositDatum.withdrawal_credentials),
+    amount: BigInt(depositDatum.amount),
+    signature: bufferHex(depositDatum.signature),
+  };
+
+  if (
+    bufferHex(depositDatum.deposit_message_root).compare(
+      DepositMessage.hashTreeRoot(depositMessage)
+    ) === 0 &&
+    bufferHex(depositDatum.deposit_data_root).compare(
+      DepositData.hashTreeRoot(depositData)
+    ) === 0
+  ) {
+    return true;
+  }
+  return false;
+};
+
+export const SigningData = new ContainerType({
+  fields: {
+    objectRoot: new ByteVectorType({
+      length: 32,
+    }), // Ideally this would be a RootType, but AFIK, there is no generic expanded type for roots in @chainsafe/ssz
+    domain: new ByteVectorType({
+      length: 32,
+    }),
+  },
+});
+
+export interface SigningData {
+  objectRoot: ByteVector;
+  domain: ByteVector;
+}
+
+export const ForkData = new ContainerType({
+  fields: {
+    currentVersion: new ByteVectorType({
+      length: 4,
+    }),
+    genesisValidatorsRoot: new ByteVectorType({
+      length: 32,
+    }),
+  },
+});
+
+export interface ForkData {
+  currentVersion: ByteVector;
+  genesisValidatorsRoot: ByteVector;
+}

--- a/src/utils/envVars.ts
+++ b/src/utils/envVars.ts
@@ -15,3 +15,12 @@ export const CONTRACT_ADDRESS = '0x4DC8B546b93131309c82505a6fdfB978D311bf45';
 export const MAINNET_ETH_REQUIREMENT = 524288;
 export const PRICE_PER_VALIDATOR = 3.2;
 export const IS_MAINNET = false;
+
+// eth2.0 specs constants
+export const BLS_WITHDRAWAL_PREFIX = Buffer.from('00', 'hex');
+export const DOMAIN_DEPOSIT = Buffer.from('03000000', 'hex');
+export const EMPTY_ROOT = Buffer.from(
+  '0000000000000000000000000000000000000000000000000000000000000000',
+  'hex'
+);
+export const GENESIS_FORK_VERSION = Buffer.from('00000000', 'hex');

--- a/src/utils/verifySignature.ts
+++ b/src/utils/verifySignature.ts
@@ -1,25 +1,48 @@
-import crypto from 'crypto';
 import { verify } from '@chainsafe/bls';
+import { DepositKeyInterface } from '../store/reducers';
+import { DOMAIN_DEPOSIT, EMPTY_ROOT, GENESIS_FORK_VERSION } from './envVars';
+import { bufferHex, ForkData, SigningData } from './SSZ';
 
-const bufferHex = (x: string): Buffer => Buffer.from(x, 'hex');
-const sha256 = (x: Buffer): Buffer =>
-  crypto
-    .createHash('sha256')
-    .update(x)
-    .digest();
+const computeForkDataRoot = (
+  currentVersion: Uint8Array,
+  genesisValidatorsRoot: Uint8Array
+): Uint8Array => {
+  const forkData: ForkData = {
+    currentVersion,
+    genesisValidatorsRoot,
+  };
+  return ForkData.hashTreeRoot(forkData);
+};
+
+const computeDomain = (
+  domainType: Buffer,
+  forkVersion: Buffer = GENESIS_FORK_VERSION,
+  genesisValidatorsRoot: Buffer = EMPTY_ROOT
+): Uint8Array => {
+  const forkDataRoot = computeForkDataRoot(forkVersion, genesisValidatorsRoot);
+  const domain = new Uint8Array(32);
+  domain.set(domainType);
+  domain.set(forkDataRoot.subarray(0, 28), 4);
+  return domain;
+};
+
+const computeSigningRoot = (
+  sszObjectRoot: Uint8Array,
+  domain: Uint8Array
+): Uint8Array => {
+  const signingData: SigningData = {
+    objectRoot: sszObjectRoot,
+    domain,
+  };
+  return SigningData.hashTreeRoot(signingData);
+};
 
 // Note: usage of this method requires awaiting the initBLS() method from "@chainsafe/bls";
-export const verifySignature = (
-  pubkey: string,
-  signature: string,
-  depositDataRoot: string
-): boolean => {
-  const pubkeyBuffer = bufferHex(pubkey);
-  const signatureBuffer = bufferHex(signature);
-  const depositDataRootBuffer = bufferHex(depositDataRoot);
-  const domain = bufferHex(
-    '0300000000000000000000000000000000000000000000000000000000000000'
-  );
-  const signingRoot = sha256(Buffer.concat([depositDataRootBuffer, domain]));
+export const verifySignature = (depositDatum: DepositKeyInterface): boolean => {
+  const pubkeyBuffer = bufferHex(depositDatum.pubkey);
+  const signatureBuffer = bufferHex(depositDatum.signature);
+  const depositMessageBuffer = bufferHex(depositDatum.deposit_message_root);
+  const domain = computeDomain(DOMAIN_DEPOSIT);
+  const signingRoot = computeSigningRoot(depositMessageBuffer, domain);
   return verify(pubkeyBuffer, signingRoot, signatureBuffer);
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,11 @@
 # yarn lockfile v1
 
 
+"@assemblyscript/loader@^0.9.2":
+  version "0.9.4"
+  resolved "https://registry.yarnpkg.com/@assemblyscript/loader/-/loader-0.9.4.tgz#a483c54c1253656bb33babd464e3154a173e1577"
+  integrity sha512-HazVq9zwTVwGmqdwYzu7WyQ6FQVZ7SwET0KKQuKm55jD0IfUpZgN0OPIiZG3zV1iSrVYcN0bdwLRXI/VNCYsUA==
+
 "@babel/code-frame@7.8.3", "@babel/code-frame@^7.0.0", "@babel/code-frame@^7.8.3":
   version "7.8.3"
   resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.8.3.tgz#33e25903d7481181534e12ec0a25f16b6fcf419e"
@@ -946,6 +951,14 @@
     lodash "^4.17.13"
     to-fast-properties "^2.0.0"
 
+"@chainsafe/as-sha256@^0.2.0":
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/@chainsafe/as-sha256/-/as-sha256-0.2.0.tgz#3ebe061d59d30af9e95a8c22ff4813cbf0e89dbc"
+  integrity sha512-reKklZhY4jSj7JdxdAjUfsaiMt2pdm8V/IqlOR5c4m6Y4tRCxt4f0HBMfyiE2ZQF4tqPPqRVf/ulXwK+LjLIxw==
+  dependencies:
+    "@assemblyscript/loader" "^0.9.2"
+    buffer "^5.4.3"
+
 "@chainsafe/bls-hd-key@^0.0.1":
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/@chainsafe/bls-hd-key/-/bls-hd-key-0.0.1.tgz#143ff16d2dcc2ec7a0b51e211d6cadabdd65f2df"
@@ -989,6 +1002,22 @@
   version "0.10.1-fix"
   resolved "https://registry.yarnpkg.com/@chainsafe/eth2-spec-tests/-/eth2-spec-tests-0.10.1-fix.tgz#c0fb839b5b93fae0a7cd247fd686d2a9ea926240"
   integrity sha512-mnfIDUFZ/IsAHmJQ7hkZ3t3s7rxrr5olLz3pH1RS2kWsuQonAKzVOZTQNkHYowpeI4ebYo8H+NPRtD5mkbTTzg==
+
+"@chainsafe/persistent-merkle-tree@^0.1.2":
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/@chainsafe/persistent-merkle-tree/-/persistent-merkle-tree-0.1.2.tgz#d052e068fa69be60117f47d686b28caf4b6d9b5a"
+  integrity sha512-W3WLCMnuYpXHALnDD1wd09H8m3dNtv1Rqx8+3VS/6gbILJaydGDUvroDIltshRg3bpVMTsTSxAM54J9ddNOApw==
+  dependencies:
+    "@chainsafe/as-sha256" "^0.2.0"
+
+"@chainsafe/ssz@^0.6.4":
+  version "0.6.4"
+  resolved "https://registry.yarnpkg.com/@chainsafe/ssz/-/ssz-0.6.4.tgz#1ee5e5599790a34f16406cd743ad83c9dc1d6bee"
+  integrity sha512-FeBwchyzSXBNJ/xToMDeldwM1IARIul9DZpEFLlzktKM+1zaJ9zRE2gMZf1dPPcUB15053dkb3ZsdqTIlm+BaA==
+  dependencies:
+    "@chainsafe/as-sha256" "^0.2.0"
+    "@chainsafe/persistent-merkle-tree" "^0.1.2"
+    case "^1.6.3"
 
 "@cnakazawa/watch@^1.0.3":
   version "1.0.4"
@@ -4144,6 +4173,11 @@ case-sensitive-paths-webpack-plugin@2.3.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/case-sensitive-paths-webpack-plugin/-/case-sensitive-paths-webpack-plugin-2.3.0.tgz#23ac613cc9a856e4f88ff8bb73bbb5e989825cf7"
   integrity sha512-/4YgnZS8y1UXXmC02xD5rRrBEu6T5ub+mQHLNRj0fzTRbgdBYhsNo2V5EqwgqrExjxsjtF/OpAKAMkKsxbD5XQ==
+
+case@^1.6.3:
+  version "1.6.3"
+  resolved "https://registry.yarnpkg.com/case/-/case-1.6.3.tgz#0a4386e3e9825351ca2e6216c60467ff5f1ea1c9"
+  integrity sha512-mzDSXIPaFwVDvZAHqZ9VlbyF4yyXRuX6IvB06WvPYkqJVO24kX1PPhv9bfpKNFZyxYFmmgo03HUiD8iklmJYRQ==
 
 caseless@~0.12.0:
   version "0.12.0"


### PR DESCRIPTION
At the moment, the signature is verified against the root provided by the deposit-cli. This is unsafe if the root is not correctly calculated, the message that is signed could be incorrect.

In addition to the above, the deposit data json checker was brittle.

This addresses the above by using @chainsafe/ssz to verify the root as well as implementing the signature verification methods from the eth2-spec.

* Closes #61 
* Resolves ethereum/eth2.0-deposit-cli/issues/23 (Root re-verification)
* Required for ethereum/eth2.0-deposit-cli/pull/32 (`fork_version `)

@hwwhww, I'd like your review for the root checking & signature verification
@Battenfield, Please can you check my typescript.