### PR TITLE
Pulls fork_version from deposit_data.json

### DIFF
--- a/src/pages/UploadValidator/validateDepositKey.ts
+++ b/src/pages/UploadValidator/validateDepositKey.ts
@@ -17,7 +17,8 @@ const validateFieldFormatting = (
     !depositDatum.amount ||
     !depositDatum.signature ||
     !depositDatum.deposit_message_root ||
-    !depositDatum.deposit_data_root
+    !depositDatum.deposit_data_root ||
+    !depositDatum.fork_version
   ) {
     return false;
   }
@@ -29,18 +30,20 @@ const validateFieldFormatting = (
     typeof depositDatum.amount !== 'number' ||
     typeof depositDatum.signature !== 'string' ||
     typeof depositDatum.deposit_message_root !== 'string' ||
-    typeof depositDatum.deposit_data_root !== 'string'
+    typeof depositDatum.deposit_data_root !== 'string' ||
+    typeof depositDatum.fork_version !== 'string'
   ) {
     return false;
   }
 
-  // check length of strings
+  // check length of strings (note: using string length, so 1 byte = 2 chars)
   if (
     depositDatum.pubkey.length !== 96 ||
     depositDatum.withdrawal_credentials.length !== 64 ||
     depositDatum.signature.length !== 192 ||
     depositDatum.deposit_message_root.length !== 64 ||
-    depositDatum.deposit_data_root.length !== 64
+    depositDatum.deposit_data_root.length !== 64 ||
+    depositDatum.fork_version.length !== 8
   ) {
     return false;
   }

--- a/src/store/reducers/depositFileReducer.ts
+++ b/src/store/reducers/depositFileReducer.ts
@@ -12,6 +12,7 @@ export interface DepositKeyInterface {
   signature: string;
   deposit_message_root: string;
   deposit_data_root: string;
+  fork_version: string;
   transactionStatus: TransactionStatus;
   txHash?: string;
 }

--- a/src/utils/verifySignature.ts
+++ b/src/utils/verifySignature.ts
@@ -42,7 +42,8 @@ export const verifySignature = (depositDatum: DepositKeyInterface): boolean => {
   const pubkeyBuffer = bufferHex(depositDatum.pubkey);
   const signatureBuffer = bufferHex(depositDatum.signature);
   const depositMessageBuffer = bufferHex(depositDatum.deposit_message_root);
-  const domain = computeDomain(DOMAIN_DEPOSIT);
+  const forkVersion = bufferHex(depositDatum.fork_version);
+  const domain = computeDomain(DOMAIN_DEPOSIT, forkVersion);
   const signingRoot = computeSigningRoot(depositMessageBuffer, domain);
   return verify(pubkeyBuffer, signingRoot, signatureBuffer);
 };


### PR DESCRIPTION
Different chains require different `fork_versions`. These need to be coordinated between the CLI and the launchpad.

Required for merging ethereum/eth2.0-deposit-cli/pull/32