### PR TITLE
Fixes #87: BigInt dependency that caused browser compatibility issues

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -7,7 +7,6 @@ module.exports = {
   globals: {
     Atomics: 'readonly',
     SharedArrayBuffer: 'readonly',
-    BigInt: true,
   },
   parser: '@typescript-eslint/parser',
   parserOptions: {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "dependencies": {
     "@chainsafe/bls": "^1.0.0",
-    "@chainsafe/ssz": "^0.6.4",
+    "@chainsafe/ssz": "^0.6.6",
     "@ethersproject/providers": "^5.0.0-beta.151",
     "@ethersproject/units": "^5.0.0-beta.132",
     "@types/react-animate-on-scroll": "^2.1.2",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "dependencies": {
     "@chainsafe/bls": "^1.0.0",
-    "@chainsafe/ssz": "^0.6.6",
+    "@chainsafe/ssz": "^0.6.7",
     "@ethersproject/providers": "^5.0.0-beta.151",
     "@ethersproject/units": "^5.0.0-beta.132",
     "@types/react-animate-on-scroll": "^2.1.2",

--- a/src/contractAbi.ts
+++ b/src/contractAbi.ts
@@ -17,7 +17,7 @@ export const contractAbi: EFAbi[] = [
   },
   {
     outputs: [],
-    inputs: [{ type: 'address', name: '_drain_address' }],
+    inputs: [],
     constant: false,
     payable: false,
     type: 'constructor',
@@ -29,7 +29,6 @@ export const contractAbi: EFAbi[] = [
     constant: true,
     payable: false,
     type: 'function',
-    gas: 95628,
   },
   {
     name: 'get_deposit_count',
@@ -38,7 +37,6 @@ export const contractAbi: EFAbi[] = [
     constant: true,
     payable: false,
     type: 'function',
-    gas: 18231,
   },
   {
     name: 'deposit',
@@ -52,7 +50,6 @@ export const contractAbi: EFAbi[] = [
     constant: false,
     payable: true,
     type: 'function',
-    gas: 1342274,
   },
   {
     name: 'drain',
@@ -61,15 +58,5 @@ export const contractAbi: EFAbi[] = [
     constant: false,
     payable: false,
     type: 'function',
-    gas: 35831,
-  },
-  {
-    name: 'drain_address',
-    outputs: [{ type: 'address', name: 'out' }],
-    inputs: [],
-    constant: true,
-    payable: false,
-    type: 'function',
-    gas: 701,
   },
 ];

--- a/src/pages/UploadValidator/validateDepositKey.ts
+++ b/src/pages/UploadValidator/validateDepositKey.ts
@@ -6,6 +6,7 @@ import { initBLS } from '@chainsafe/bls';
 import { verifySignature } from '../../utils/verifySignature';
 import { verifyDepositRoots } from '../../utils/SSZ';
 import { DepositKeyInterface } from '../../store/reducers';
+import { MIN_DEPOSIT_AMOUNT, MAX_DEPOSIT_AMOUNT } from '../../utils/envVars';
 
 const validateFieldFormatting = (
   depositDatum: DepositKeyInterface
@@ -44,6 +45,12 @@ const validateFieldFormatting = (
     depositDatum.deposit_message_root.length !== 64 ||
     depositDatum.deposit_data_root.length !== 64 ||
     depositDatum.fork_version.length !== 8
+  ) {
+    return false;
+  }
+  if (
+    depositDatum.amount < MIN_DEPOSIT_AMOUNT ||
+    depositDatum.amount > MAX_DEPOSIT_AMOUNT
   ) {
     return false;
   }

--- a/src/utils/SSZ.ts
+++ b/src/utils/SSZ.ts
@@ -66,19 +66,15 @@ export const verifyDepositRoots = (
     amount: Number(depositDatum.amount),
     signature: bufferHex(depositDatum.signature),
   };
-  try {
-    if (
-      bufferHex(depositDatum.deposit_message_root).compare(
-        DepositMessage.hashTreeRoot(depositMessage)
-      ) === 0 &&
-      bufferHex(depositDatum.deposit_data_root).compare(
-        DepositData.hashTreeRoot(depositData)
-      ) === 0
-    ) {
-      return true;
-    }
-  } catch (err) {
-    console.log(err);
+  if (
+    bufferHex(depositDatum.deposit_message_root).compare(
+      DepositMessage.hashTreeRoot(depositMessage)
+    ) === 0 &&
+    bufferHex(depositDatum.deposit_data_root).compare(
+      DepositData.hashTreeRoot(depositData)
+    ) === 0
+  ) {
+    return true;
   }
   return false;
 };

--- a/src/utils/SSZ.ts
+++ b/src/utils/SSZ.ts
@@ -1,5 +1,5 @@
 import {
-  BigIntUintType,
+  NumberUintType,
   ByteVector,
   ByteVectorType,
   ContainerType,
@@ -16,7 +16,7 @@ const DepositMessage = new ContainerType({
     withdrawalCredentials: new ByteVectorType({
       length: 32,
     }),
-    amount: new BigIntUintType({
+    amount: new NumberUintType({
       byteLength: 8,
     }),
   },
@@ -25,7 +25,7 @@ const DepositMessage = new ContainerType({
 interface DepositMessage {
   pubkey: ByteVector;
   withdrawalCredentials: ByteVector;
-  amount: BigInt;
+  amount: Number;
 }
 
 const DepositData = new ContainerType({
@@ -36,7 +36,7 @@ const DepositData = new ContainerType({
     withdrawalCredentials: new ByteVectorType({
       length: 32,
     }),
-    amount: new BigIntUintType({
+    amount: new NumberUintType({
       byteLength: 8,
     }),
     signature: new ByteVectorType({
@@ -48,7 +48,7 @@ const DepositData = new ContainerType({
 interface DepositData {
   pubkey: ByteVector;
   withdrawalCredentials: ByteVector;
-  amount: BigInt;
+  amount: Number;
   signature: ByteVector;
 }
 
@@ -58,24 +58,27 @@ export const verifyDepositRoots = (
   const depositMessage: DepositMessage = {
     pubkey: bufferHex(depositDatum.pubkey),
     withdrawalCredentials: bufferHex(depositDatum.withdrawal_credentials),
-    amount: BigInt(depositDatum.amount),
+    amount: Number(depositDatum.amount),
   };
   const depositData: DepositData = {
     pubkey: bufferHex(depositDatum.pubkey),
     withdrawalCredentials: bufferHex(depositDatum.withdrawal_credentials),
-    amount: BigInt(depositDatum.amount),
+    amount: Number(depositDatum.amount),
     signature: bufferHex(depositDatum.signature),
   };
-
-  if (
-    bufferHex(depositDatum.deposit_message_root).compare(
-      DepositMessage.hashTreeRoot(depositMessage)
-    ) === 0 &&
-    bufferHex(depositDatum.deposit_data_root).compare(
-      DepositData.hashTreeRoot(depositData)
-    ) === 0
-  ) {
-    return true;
+  try {
+    if (
+      bufferHex(depositDatum.deposit_message_root).compare(
+        DepositMessage.hashTreeRoot(depositMessage)
+      ) === 0 &&
+      bufferHex(depositDatum.deposit_data_root).compare(
+        DepositData.hashTreeRoot(depositData)
+      ) === 0
+    ) {
+      return true;
+    }
+  } catch (err) {
+    console.log(err);
   }
   return false;
 };

--- a/src/utils/envVars.ts
+++ b/src/utils/envVars.ts
@@ -11,7 +11,7 @@ export const RPC_URL_MAINNET = `https://mainnet.infura.io/v3/${INFURA_PROJECT_ID
 export const FORTMATIC_KEY = 'pk_test_D113D979E0D3508F';
 export const ALETHIO_URL = 'https://explorer.goerli.aleth.io/tx';
 export const ETHERSCAN_URL = 'https://goerli.etherscan.io/tx';
-export const CONTRACT_ADDRESS = '0x4DC8B546b93131309c82505a6fdfB978D311bf45';
+export const CONTRACT_ADDRESS = '0x344b3a521ded954b4fa9ec8cc1d999631c998daa';
 export const MAINNET_ETH_REQUIREMENT = 524288;
 export const IS_MAINNET = false;
 

--- a/src/utils/envVars.ts
+++ b/src/utils/envVars.ts
@@ -13,7 +13,6 @@ export const ALETHIO_URL = 'https://explorer.goerli.aleth.io/tx';
 export const ETHERSCAN_URL = 'https://goerli.etherscan.io/tx';
 export const CONTRACT_ADDRESS = '0x4DC8B546b93131309c82505a6fdfB978D311bf45';
 export const MAINNET_ETH_REQUIREMENT = 524288;
-export const PRICE_PER_VALIDATOR = 3.2;
 export const IS_MAINNET = false;
 
 // eth2.0 specs constants
@@ -24,3 +23,7 @@ export const EMPTY_ROOT = Buffer.from(
   'hex'
 );
 export const GENESIS_FORK_VERSION = Buffer.from('00000000', 'hex');
+export const GWEI = 1e9;
+export const MIN_DEPOSIT_AMOUNT = 1 * GWEI;
+export const MAX_DEPOSIT_AMOUNT = 32 * GWEI;
+export const PRICE_PER_VALIDATOR = MAX_DEPOSIT_AMOUNT / GWEI;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1010,10 +1010,10 @@
   dependencies:
     "@chainsafe/as-sha256" "^0.2.0"
 
-"@chainsafe/ssz@^0.6.6":
-  version "0.6.6"
-  resolved "https://registry.yarnpkg.com/@chainsafe/ssz/-/ssz-0.6.6.tgz#f0524621376731e1c230e5de33d022de61f788c4"
-  integrity sha512-QmfIsH30Uy+BZC1lsoDQRDJUdVikQIraeke9BFMzeZ3A04VLwatr/NuC4vLteqv/62ohyzfmKtF8CIXxShu8XQ==
+"@chainsafe/ssz@^0.6.7":
+  version "0.6.7"
+  resolved "https://registry.yarnpkg.com/@chainsafe/ssz/-/ssz-0.6.7.tgz#472683c2d553fbfdb950b7805596f85c0bf46991"
+  integrity sha512-1r6yGc0fa7GMik7xEYKpYm7bTLgSeaLnbER9maS/9PLrpWz794njrwvrREpcUu/yks7SWuKSNJX1b+cAE6x0bA==
   dependencies:
     "@chainsafe/as-sha256" "^0.2.0"
     "@chainsafe/persistent-merkle-tree" "^0.1.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1003,20 +1003,20 @@
   resolved "https://registry.yarnpkg.com/@chainsafe/eth2-spec-tests/-/eth2-spec-tests-0.10.1-fix.tgz#c0fb839b5b93fae0a7cd247fd686d2a9ea926240"
   integrity sha512-mnfIDUFZ/IsAHmJQ7hkZ3t3s7rxrr5olLz3pH1RS2kWsuQonAKzVOZTQNkHYowpeI4ebYo8H+NPRtD5mkbTTzg==
 
-"@chainsafe/persistent-merkle-tree@^0.1.2":
-  version "0.1.2"
-  resolved "https://registry.yarnpkg.com/@chainsafe/persistent-merkle-tree/-/persistent-merkle-tree-0.1.2.tgz#d052e068fa69be60117f47d686b28caf4b6d9b5a"
-  integrity sha512-W3WLCMnuYpXHALnDD1wd09H8m3dNtv1Rqx8+3VS/6gbILJaydGDUvroDIltshRg3bpVMTsTSxAM54J9ddNOApw==
+"@chainsafe/persistent-merkle-tree@^0.1.3":
+  version "0.1.3"
+  resolved "https://registry.yarnpkg.com/@chainsafe/persistent-merkle-tree/-/persistent-merkle-tree-0.1.3.tgz#95d16f5faefc4d75f2861859ec5474f34767a4f7"
+  integrity sha512-ZFu7Zoxjt1A9W5whMVlwWJ+dGMF6+iL99lI9g7kIaG1JbI37M0F4TszO5Fe758e6/XJdGl5SFLi+923JYVB/ow==
   dependencies:
     "@chainsafe/as-sha256" "^0.2.0"
 
-"@chainsafe/ssz@^0.6.4":
-  version "0.6.4"
-  resolved "https://registry.yarnpkg.com/@chainsafe/ssz/-/ssz-0.6.4.tgz#1ee5e5599790a34f16406cd743ad83c9dc1d6bee"
-  integrity sha512-FeBwchyzSXBNJ/xToMDeldwM1IARIul9DZpEFLlzktKM+1zaJ9zRE2gMZf1dPPcUB15053dkb3ZsdqTIlm+BaA==
+"@chainsafe/ssz@^0.6.6":
+  version "0.6.6"
+  resolved "https://registry.yarnpkg.com/@chainsafe/ssz/-/ssz-0.6.6.tgz#f0524621376731e1c230e5de33d022de61f788c4"
+  integrity sha512-QmfIsH30Uy+BZC1lsoDQRDJUdVikQIraeke9BFMzeZ3A04VLwatr/NuC4vLteqv/62ohyzfmKtF8CIXxShu8XQ==
   dependencies:
     "@chainsafe/as-sha256" "^0.2.0"
-    "@chainsafe/persistent-merkle-tree" "^0.1.2"
+    "@chainsafe/persistent-merkle-tree" "^0.1.3"
     case "^1.6.3"
 
 "@cnakazawa/watch@^1.0.3":


### PR DESCRIPTION
#83 Added SSZ verification of the roots in the deposit-json file. Unfortunately, as was presented in #87, this broke compatibility with some browsers (those that do not support ES2020 yet).

@wemeetagain pushed some changes to @chainsafe/SSZ and its dependancies so that `BigInt`s are not called while calculating hash-tree-roots for sufficiently small ints.

This PR bumps the SSZ version, changes the local types, and performs range checks on the deposit amount.