### PR TITLE
Page template for new non-workflow pages

### DIFF
--- a/src/components/PageTemplate.tsx
+++ b/src/components/PageTemplate.tsx
@@ -3,7 +3,6 @@ import styled from 'styled-components';
 import { RouteComponentProps, withRouter } from 'react-router-dom';
 import { AppBar } from './AppBar';
 import { Heading } from './Heading';
-import { DesktopOnlyModal } from './DesktopOnlyModal';
 
 const Content = styled.div`
   width: 100%;
@@ -31,10 +30,6 @@ interface Props extends RouteComponentProps {
 }
 
 const _PageTemplate = ({ children, title }: Props): JSX.Element => {
-  if ((window as any).mobileCheck()) {
-    return <DesktopOnlyModal />;
-  }
-
   return (
     <RainbowBackground>
       <AppBar />

--- a/src/components/PageTemplate.tsx
+++ b/src/components/PageTemplate.tsx
@@ -1,0 +1,53 @@
+import React from 'react';
+import styled from 'styled-components';
+import { RouteComponentProps, withRouter } from 'react-router-dom';
+import { AppBar } from './AppBar';
+import { Heading } from './Heading';
+import { DesktopOnlyModal } from './DesktopOnlyModal';
+
+const Content = styled.div`
+  width: 100%;
+  max-width: 1024px;
+  margin: 30px 0;
+  position: relative;
+`;
+
+const Gutter = styled.div`
+  padding: 0 48px;
+  display: flex;
+  justify-content: center;
+`;
+
+const RainbowBackground = styled.div`
+  background-image: ${p =>
+    `radial-gradient(circle at 100% -80%, ${p.theme.rainbowLight})`};
+  min-height: 100vh;
+`;
+
+interface Props extends RouteComponentProps {
+  children?: React.ReactNode;
+  title: string;
+  history: any;
+}
+
+const _PageTemplate = ({ children, title }: Props): JSX.Element => {
+  if ((window as any).mobileCheck()) {
+    return <DesktopOnlyModal />;
+  }
+
+  return (
+    <RainbowBackground>
+      <AppBar />
+      <Gutter>
+        <Content>
+          <Heading level={2} size="medium" color="blueDark" className="mb40">
+            {title}
+          </Heading>
+          {children}
+        </Content>
+      </Gutter>
+    </RainbowBackground>
+  );
+};
+
+export const PageTemplate = withRouter(_PageTemplate);


### PR DESCRIPTION
- Adds in `<PageTemplate/>` which can be used for informational pages

<img width="1198" alt="Screen Shot 2020-06-17 at 11 48 57 PM" src="https://user-images.githubusercontent.com/7051522/84987536-3328a800-b0f5-11ea-86c0-4e12fb7ded59.png">
