### PR TITLE
Remove all references to "eth1"

### DIFF
--- a/src/pages/Acknowledgements/pageContent.tsx
+++ b/src/pages/Acknowledgements/pageContent.tsx
@@ -51,7 +51,7 @@ export const pageContent = {
         reversed.
       </Text>
     ),
-    acknowledgementText: `I understand that I need to deposit ${PRICE_PER_VALIDATOR} ${TICKER_NAME} to sign up as a validator. And that the transfer of ${TICKER_NAME} from eth1 to to eth2 is one-way, and non-reversible.`,
+    acknowledgementText: `I understand that I need to deposit ${PRICE_PER_VALIDATOR} ${TICKER_NAME} to sign up as a validator, and that the transfer of ${TICKER_NAME} into eth2 is one-way, and non-reversible.`,
   },
   [AcknowledgementIdsEnum.responsibilities]: {
     title: 'Responsibilities',

--- a/src/pages/Acknowledgements/pageContent.tsx
+++ b/src/pages/Acknowledgements/pageContent.tsx
@@ -27,7 +27,7 @@ export const pageContent = {
           Importantly, validators need to post {TICKER_NAME} as collateral - in
           other words, have some funds at stake. The only way to become a
           validator is to make a one-way {TICKER_NAME} transaction to the
-          deposit contract on Ethereum 1.0.
+          deposit contract on the current Ethereum chain.
         </Text>
         <Link
           external

--- a/src/pages/FAQ/index.jsx
+++ b/src/pages/FAQ/index.jsx
@@ -63,8 +63,8 @@ export const FAQ = () => {
           <section>
             <Heading level={4}>What is the deposit contract?</Heading>
             <Text className="mt10">
-              You can think of it as a transfer of funds between Ethereum 1.0
-              accounts and Ethereum 2.0 validators.
+              You can think of it as a transfer of funds between Ethereum
+              accounts and eth2 validators.
             </Text>
             <Text className="mt10">
               It specifies who is staking, who is validating, how much is being

--- a/src/pages/Landing/Introduction.tsx
+++ b/src/pages/Landing/Introduction.tsx
@@ -74,8 +74,9 @@ export const Introduction = (): JSX.Element => {
               without compromising on decentralization.
             </Text>
             <Text className="mt25">
-              In contrast to eth1, eth2 uses proof-of-stake (PoS) to secure its
-              network. And while eth1 will continue to exist as its own
+              In contrast to the Ethereum chain, as it currently stands, eth2
+              uses proof-of-stake (PoS) to secure its network. And while
+              Ethereum as you know and love it will continue to exist as its own
               independent proof-of-work chain for a little while to come, the
               transition towards PoS starts now.
             </Text>

--- a/src/pages/Phishing/index.tsx
+++ b/src/pages/Phishing/index.tsx
@@ -53,7 +53,9 @@ export const Phishing = () => {
             </Text>
           </li>
           <li>
-            <Text className="mt10">On your favorite eth1 block explorer:</Text>
+            <Text className="mt10">
+              On your favorite Ethereum block explorer:
+            </Text>
             <ul>
               <li>
                 <Text className="mt10">Are there recent 32ETH deposits?</Text>


### PR DESCRIPTION
Changes wording to emphasise that eth2 is an upgrade to the consensus of Ethereum, not a replacement of "eth1".