### PR TITLE
Clarifies numbers on network status

### DIFF
--- a/src/pages/Landing/NetworkStatus/index.tsx
+++ b/src/pages/Landing/NetworkStatus/index.tsx
@@ -71,7 +71,7 @@ const PreThresholdSubText = ({
         {numberWithCommas(amountEth)} {TICKER_NAME}
       </BoldGreen>
       <Text size="small" style={{ marginTop: '2px' }}>
-        Current staking balance
+        current staking balance
       </Text>
     </span>
     <Text
@@ -82,7 +82,7 @@ const PreThresholdSubText = ({
         {calculateLaunchThreshold(amountEth)} {TICKER_NAME}
         {mobile ? <br /> : <>&nbsp;</>}
       </strong>
-      Launch threshold
+      until launch threshold
     </Text>
   </div>
 );
@@ -100,7 +100,7 @@ const PostThresholdSubText = ({
         {numberWithCommas(ETH_REQUIREMENT)} {TICKER_NAME}
         {mobile ? <br /> : <>&nbsp;</>}
       </strong>
-      Launch threshold
+      until launch threshold
     </Text>
     <span
       className={`flex ${
@@ -111,7 +111,7 @@ const PostThresholdSubText = ({
         {numberWithCommas(amountEth)} {TICKER_NAME}
       </BoldGreen>
       <Text size="small" style={{ marginTop: '2px' }}>
-        Current staking balance
+        current staking balance
       </Text>
     </span>
   </div>


### PR DESCRIPTION
The text of the Network status graphs is rather unclear as to what numbers are what (see picture below), this PR clarifies that.

<img width="1329" alt="Screenshot 2020-07-23 at 4 20 04 PM" src="https://user-images.githubusercontent.com/12530043/88301621-235c3f00-cd05-11ea-907a-d1a565dfb237.png">
