### PR TITLE
[Urgent] Update TX status to PENDING in `handleMultipleTransactions`

### DIFF
--- a/src/pages/Transactions/Keylist/ActionButton.tsx
+++ b/src/pages/Transactions/Keylist/ActionButton.tsx
@@ -41,12 +41,7 @@ export const ActionButton = ({ status, txHash, onClick, pubkey }: Props) => {
     );
   }
   if (status === TransactionStatus.PENDING) {
-    return (
-      <Container onClick={onClick}>
-        <ButtonText>Retry</ButtonText>
-        <FormNextLink />
-      </Container>
-    );
+    return <div className="flex" />;
   }
   if (status === TransactionStatus.STARTED) {
     return (

--- a/src/pages/Transactions/index.tsx
+++ b/src/pages/Transactions/index.tsx
@@ -61,7 +61,9 @@ const _TransactionsPage = ({
 
   const totalTxCount = depositKeys.length;
   const remainingTxCount = depositKeys.filter(
-    file => file.transactionStatus === TransactionStatus.READY
+    file =>
+      file.transactionStatus === TransactionStatus.READY ||
+      file.transactionStatus === TransactionStatus.REJECTED
   ).length;
   const allTxConfirmed = _every(
     depositKeys.map(
@@ -100,12 +102,8 @@ const _TransactionsPage = ({
   };
 
   const handleAllTransactionsClick = () => {
-    const remainingTxs = depositKeys.filter(
-      key => key.transactionStatus === TransactionStatus.READY
-    );
-
     handleMultipleTransactions(
-      remainingTxs,
+      depositKeys,
       connector as AbstractConnector,
       account,
       dispatchTransactionStatusUpdate
@@ -136,7 +134,7 @@ const _TransactionsPage = ({
         </Text>
         <Text className="mt10">
           You can initiate these all at once, or sign them individually from the
-          keylist below
+          key-list below
         </Text>
         <div className="flex center mt30">
           <Button


### PR DESCRIPTION
Solves double deposit issue explained in #183. In the change from offering one-at-a-time deposit processing to multiple deposits via the "Initiate All Deposits" button, the status of a transaction was no longer updated to reflect that the TX was `PENDING`. This PR solves that as well as cleans up the `handleMultipleTransactions` recursion.