### PR TITLE
Fix Prysm Spadina Documentation Link

### DIFF
--- a/src/pages/Clients/Eth2/Prysm.tsx
+++ b/src/pages/Clients/Eth2/Prysm.tsx
@@ -35,7 +35,7 @@ export const PrysmDetails = ({ shortened }: { shortened?: boolean }) => (
       <Link
         primary
         external
-        to="https://docs.prylabs.network/docs/testnet/medalla/"
+        to="https://docs.prylabs.network/docs/testnet/spadina/"
         withArrow
       >
         Run Prysm


### PR DESCRIPTION
Fixes https://github.com/ethereum/eth2.0-deposit/issues/179, this PR adds the right documentation link for Prysm's Spadina testnet support