### PR TITLE
Remove Alethio links and vars

### DIFF
--- a/src/pages/Transactions/Keylist/ActionButton.tsx
+++ b/src/pages/Transactions/Keylist/ActionButton.tsx
@@ -5,7 +5,6 @@ import { Text } from '../../../components/Text';
 import { Link } from '../../../components/Link';
 import { TransactionStatus } from '../../../store/actions/depositFileActions';
 import {
-  ALETHIO_URL,
   ETHERSCAN_URL,
   BEACONSCAN_URL,
   BEACONCHAIN_URL,
@@ -46,11 +45,6 @@ export const ActionButton = ({ status, txHash, onClick, pubkey }: Props) => {
   if (status === TransactionStatus.STARTED) {
     return (
       <div className="flex">
-        <Link external to={`${ALETHIO_URL}/${txHash}`}>
-          <ButtonText className="mr5">
-            Alethio <Share size="small" />
-          </ButtonText>
-        </Link>
         <Link external to={`${ETHERSCAN_URL}/${txHash}`}>
           <ButtonText>
             Etherscan <Share size="small" />

--- a/src/utils/envVars.ts
+++ b/src/utils/envVars.ts
@@ -7,7 +7,6 @@ export const ENABLE_RPC_FEATURES        = Boolean(INFURA_PROJECT_ID && INFURA_PR
 export const INFURA_URL                 = `https://${IS_MAINNET ? "mainnet" : "goerli"}.infura.io/v3/${INFURA_PROJECT_ID}`;
 
 // public
-export const ALETHIO_URL                = IS_MAINNET ? 'https://explorer.aleth.io/tx' : 'https://explorer.goerli.aleth.io/tx';
 export const ETHERSCAN_URL              = IS_MAINNET ? 'https://etherscan.io/tx' : 'https://goerli.etherscan.io/tx';
 export const BEACONSCAN_URL             = process.env.REACT_APP_BEACONSCAN_URL      || "https://beaconscan.com/medalla/validator";
 export const BEACONCHAIN_URL            = process.env.REACT_APP_BEACONCHAIN_URL     || "https://medalla.beaconcha.in/validator";


### PR DESCRIPTION
Alethio links are not working as they were previously for deposit transactions. Removing them as Etherescan is sufficient for Eth 1.