### PR TITLE
Removes 'testnet' when network is 'mainnet' [Fixes #242]

### DIFF
--- a/src/pages/GenerateKeys/Option1.tsx
+++ b/src/pages/GenerateKeys/Option1.tsx
@@ -114,8 +114,9 @@ export const Option1 = ({
             --chain {ETH2_NETWORK_NAME.toLowerCase()}
           </span>{' '}
           for {ETH2_NETWORK_NAME.charAt(0).toUpperCase()}
-          {ETH2_NETWORK_NAME.toLowerCase().slice(1)} testnet, otherwise the
-          deposit will be invalid.
+          {ETH2_NETWORK_NAME.toLowerCase().slice(1)}
+          {ETH2_NETWORK_NAME.toLowerCase() !== 'mainnet' && ' testnet'},
+          otherwise the deposit will be invalid.
         </Text>
       </Alert>
       <Text>

--- a/src/pages/GenerateKeys/Option2.tsx
+++ b/src/pages/GenerateKeys/Option2.tsx
@@ -282,8 +282,9 @@ export const Option2 = ({
             --chain {ETH2_NETWORK_NAME.toLowerCase()}
           </span>{' '}
           for {ETH2_NETWORK_NAME.charAt(0).toUpperCase()}
-          {ETH2_NETWORK_NAME.toLowerCase().slice(1)} testnet, otherwise the
-          deposit will be invalid.
+          {ETH2_NETWORK_NAME.toLowerCase().slice(1)}
+          {ETH2_NETWORK_NAME.toLowerCase() !== 'mainnet' && ' testnet'},
+          otherwise the deposit will be invalid.
         </Text>
       </Alert>
       <Alert variant="warning" className="my10">


### PR DESCRIPTION
**Description**
On the **Generate Keys** page, the two options both had `testnet` hardcoded into the string after the network name. To maintain flexibility, my fix includes a conditional, where if the network name (lowercased) is anything other than 'mainnet' then ' testnet' will be added, otherwise nothing will be added. 

**Related issue**
#242 

(My first PR to this repo... let me know if there are issues, and of course, feel free to ignore 😉)