### PR TITLE
Makes 1 call to beaconchain API for all validators

### DIFF
--- a/src/store/reducers/depositFileReducer.ts
+++ b/src/store/reducers/depositFileReducer.ts
@@ -35,6 +35,27 @@ const initialState: DepositFileInterface = {
   keys: [],
 };
 
+interface BeaconchainDepositDataInterface {
+  amount: number;
+  block_number: number;
+  block_ts: number;
+  from_address: string;
+  merkletree_index: string;
+  publickey: string;
+  removed: boolean;
+  signature: string;
+  tx_hash: string;
+  tx_index: number;
+  tx_input: string;
+  valid_signature: boolean;
+  withdrawal_credentials: string;
+}
+
+export interface BeaconchainDepositInterface {
+  data: BeaconchainDepositDataInterface[];
+  status: string;
+}
+
 export const depositFileReducer = (
   state: DepositFileInterface = initialState,
   action: Action


### PR DESCRIPTION
We've been hitting rate limits (10/minute) on the beaconcha.in API because we are making 1 API call per validator. This PR makes use of the API's ability to respond to multiple simultaneous requests so that only 1 request is made to the API.