### PR TITLE
Disable Beaconscan and simplify envVars

### DIFF
--- a/src/pages/GenerateKeys/Option1.tsx
+++ b/src/pages/GenerateKeys/Option1.tsx
@@ -4,7 +4,7 @@ import { Heading } from '../../components/Heading';
 import { Text } from '../../components/Text';
 import { Link } from '../../components/Link';
 import { Alert } from '../../components/Alert';
-import { ETH2_NETWORK_NAME } from '../../utils/envVars';
+import { ETH2_NETWORK_NAME, IS_MAINNET } from '../../utils/envVars';
 import { Button } from '../../components/Button';
 import { Alert as GrommetAlert, FormNext } from 'grommet-icons';
 import githubScreenshot from '../../static/github-cli-screenshot.png';
@@ -115,8 +115,7 @@ export const Option1 = ({
           </span>{' '}
           for {ETH2_NETWORK_NAME.charAt(0).toUpperCase()}
           {ETH2_NETWORK_NAME.toLowerCase().slice(1)}
-          {ETH2_NETWORK_NAME.toLowerCase() !== 'mainnet' && ' testnet'},
-          otherwise the deposit will be invalid.
+          {!IS_MAINNET && ' testnet'}, otherwise the deposit will be invalid.
         </Text>
       </Alert>
       <Text>

--- a/src/pages/GenerateKeys/Option2.tsx
+++ b/src/pages/GenerateKeys/Option2.tsx
@@ -5,7 +5,7 @@ import { Text } from '../../components/Text';
 import { Link } from '../../components/Link';
 import { Alert } from '../../components/Alert';
 import { Code } from '../../components/Code';
-import { ETH2_NETWORK_NAME } from '../../utils/envVars';
+import { ETH2_NETWORK_NAME, IS_MAINNET } from '../../utils/envVars';
 import { colors } from '../../styles/styledComponentsTheme';
 
 const Pre = styled.pre`
@@ -283,8 +283,7 @@ export const Option2 = ({
           </span>{' '}
           for {ETH2_NETWORK_NAME.charAt(0).toUpperCase()}
           {ETH2_NETWORK_NAME.toLowerCase().slice(1)}
-          {ETH2_NETWORK_NAME.toLowerCase() !== 'mainnet' && ' testnet'},
-          otherwise the deposit will be invalid.
+          {!IS_MAINNET && ' testnet'}, otherwise the deposit will be invalid.
         </Text>
       </Alert>
       <Alert variant="warning" className="my10">

--- a/src/pages/Transactions/Keylist/ActionButton.tsx
+++ b/src/pages/Transactions/Keylist/ActionButton.tsx
@@ -9,7 +9,7 @@ import {
 } from '../../../store/actions/depositFileActions';
 import {
   BEACONCHAIN_URL,
-  BEACONSCAN_URL,
+  //   BEACONSCAN_URL,
   ETHERSCAN_URL,
 } from '../../../utils/envVars';
 import ReactTooltip from 'react-tooltip';
@@ -88,11 +88,12 @@ export const ActionButton = ({
         </span>
         <ReactTooltip id="beaconchain-warning" place="top" effect="solid" />
 
-        <Link external to={`${BEACONSCAN_URL}/0x${pubkey}`}>
+        {/* TODO: comment it out for now until beaconscan is available. */}
+        {/* <Link external to={`${BEACONSCAN_URL}/0x${pubkey}`}>
           <ButtonText>
             Beaconscan <Share size="small" />
           </ButtonText>
-        </Link>
+        </Link> */}
       </div>
     );
   }

--- a/src/utils/envVars.ts
+++ b/src/utils/envVars.ts
@@ -7,13 +7,13 @@ export const ENABLE_RPC_FEATURES        = Boolean(INFURA_PROJECT_ID && INFURA_PR
 export const INFURA_URL                 = `https://${IS_MAINNET ? "mainnet" : "goerli"}.infura.io/v3/${INFURA_PROJECT_ID}`;
 
 // public
+export const ETH2_NETWORK_NAME          = process.env.REACT_APP_ETH2_NETWORK_NAME   || 'Mainnet';
+export const TICKER_NAME                = IS_MAINNET ? 'ETH' : 'GöETH';
 export const ETHERSCAN_URL              = IS_MAINNET ? 'https://etherscan.io/tx' : 'https://goerli.etherscan.io/tx';
-export const BEACONSCAN_URL             = process.env.REACT_APP_BEACONSCAN_URL      || "https://beaconscan.com/validator";
-export const BEACONCHAIN_URL            = process.env.REACT_APP_BEACONCHAIN_URL     || "https://mainnet.beaconcha.in/validator";
+export const BEACONSCAN_URL             = IS_MAINNET ? 'https://beaconscan.com/validator' : `https://beaconscan.com/${ETH2_NETWORK_NAME.toLowerCase()}/validator`;
+export const BEACONCHAIN_URL            = `https://${ETH2_NETWORK_NAME.toLowerCase()}.beaconcha.in/validator`;
 export const FORTMATIC_KEY              = process.env.REACT_APP_FORTMATIC_KEY       || 'pk_test_D113D979E0D3508F';
 export const CONTRACT_ADDRESS           = process.env.REACT_APP_CONTRACT_ADDRESS    || '0x00000000219ab540356cBB839Cbe05303d7705Fa';
-export const ETH2_NETWORK_NAME          = process.env.REACT_APP_ETH2_NETWORK_NAME   || 'Mainnet';
-export const TICKER_NAME                = process.env.REACT_APP_TICKER_NAME         || 'ETH';
 export const MIN_DEPOSIT_CLI_VERSION    = process.env.REACT_APP_MIN_DEPOSIT_CLI_VERSION  || '1.0.0';
 export const LIGHTHOUSE_INSTALLATION_URL = process.env.REACT_APP_LIGHTHOUSE_INSTALLATION_URL || 'https://lighthouse-book.sigmaprime.io/';
 export const NIMBUS_INSTALLATION_URL    = process.env.REACT_APP_NIMBUS_INSTALLATION_URL  || 'https://status-im.github.io/nimbus-eth2/intro.html';


### PR DESCRIPTION
- Workaround for #250: Disable Beaconscan for now
- Simplify envVars: use `IS_MAINNET` and `ETH2_NETWORK_NAME` to generate `BEACONSCAN_URL` and `BEACONCHAIN_URL`.