### PR TITLE
Fix minimum geth fast sync disk size

### DIFF
--- a/src/pages/Checklist/index.tsx
+++ b/src/pages/Checklist/index.tsx
@@ -126,7 +126,7 @@ export const Checklist = () => {
             <ul>
               <li>
                 <Text>
-                  For example, you need at least 140 GB SSD to run geth fast
+                  For example, you need at least 290 GB SSD to run geth fast
                   sync on <i>mainnet</i>.
                 </Text>
               </li>

--- a/src/pages/Checklist/index.tsx
+++ b/src/pages/Checklist/index.tsx
@@ -126,8 +126,12 @@ export const Checklist = () => {
             <ul>
               <li>
                 <Text>
-                  For example, you need at least 290 GB SSD to run geth fast
-                  sync on <i>mainnet</i>.
+                  For example, you need at least ~300 GB SSD to run geth fast
+                  sync on <i>mainnet</i> in November 2020, assuming you move the{' '}
+                  <i>ancient</i> directory on a different drive. Have in mind
+                  that geth <i>chaindata</i> grows with ~1 GB per day, so you
+                  should account for enough space on your SSD and HDD until you
+                  run maintenance on the node.
                 </Text>
               </li>
             </ul>


### PR DESCRIPTION
### Issue
The "at least 140 GB SSD to run geth fast" may be outdated.
Changing it to 290 GB.

---

Thank @nonsense for [finding this issue](https://discord.com/channels/595666850260713488/598292067260825641/778352824114217003).
> A new node takes around 290 GB... and only grows from there on

Also thank @michaelsproul for [confirming the number](https://discord.com/channels/595666850260713488/598292067260825641/778472799324602378):
> I recently fast synced Geth from scratch and it's using 287 GB (122 GB hot + 165 GB freezer)

