### PR TITLE
updated for issue with time sync

### DIFF
--- a/src/pages/Checklist/index.tsx
+++ b/src/pages/Checklist/index.tsx
@@ -238,6 +238,7 @@ export const Checklist = () => {
                 <pre className="my0">
                   <span style={{ color: colors.red.medium }}>
                     {' '}
+                    sudo apt install chrony
                     sudo timedatectl set-ntp on
                   </span>
                 </pre>


### PR DESCRIPTION
When running through the checklist page, and running the `sudo timedatectl set-ntp on` command, I was running into `Failed to set ntp: NTP not supported`

However installing `chrony` fixed this. `sudo apt install chrony`

So I think it makes sense to either note that something else they will need to install, or just to plop this package in there as well. I was told this way was a bit `overkill`, but hoping this helps users moving forward. Looks like I wasn't the only one tripped up here. 