### PR TITLE
Allow retry on failed deposits

### DIFF
--- a/src/pages/Transactions/Keylist/ActionButton.tsx
+++ b/src/pages/Transactions/Keylist/ActionButton.tsx
@@ -97,10 +97,7 @@ export const ActionButton = ({
     );
   }
 
-  if (
-    transactionStatus === TransactionStatus.FAILED ||
-    transactionStatus === TransactionStatus.REJECTED
-  ) {
+  if (transactionStatus === TransactionStatus.REJECTED) {
     return (
       <Container onClick={onClick}>
         <ButtonText>Try again</ButtonText>

--- a/src/pages/Transactions/transactionUtils.tsx
+++ b/src/pages/Transactions/transactionUtils.tsx
@@ -121,7 +121,6 @@ export const handleMultipleTransactions = async (
       }
     )
     .on('error', (error: any) => {
-      console.log(error);
       if (isUserRejectionError(error)) {
         updateTransactionStatus(pubkey, TransactionStatus.REJECTED);
       } else {

--- a/src/pages/Transactions/transactionUtils.tsx
+++ b/src/pages/Transactions/transactionUtils.tsx
@@ -58,6 +58,7 @@ export const handleMultipleTransactions = async (
   const remainingTxs = depositKeys.filter(
     key =>
       key.transactionStatus === TransactionStatus.READY ||
+      key.transactionStatus === TransactionStatus.FAILED || // can be triggered by user taking too long to confirm on hardware wallet
       key.transactionStatus === TransactionStatus.REJECTED
   );
 

--- a/src/pages/Transactions/transactionUtils.tsx
+++ b/src/pages/Transactions/transactionUtils.tsx
@@ -14,25 +14,27 @@ const TX_VALUE = pricePerValidator.multipliedBy(1e18).toNumber();
 
 const isUserRejectionError = (error: any) => {
   if (error.code === 4001) return true; // metamask reject
+  if (error.code === -32603)
+    if (
+      error.message.includes(
+        'MetaMask Tx Signature: User denied transaction signature.'
+      )
+    )
+      // do nothing because there are different cases with the same error-code ;
+      return true; // metamask reject
   if (
-    error.message ===
-    'MetaMask Tx Signature: User denied transaction signature.'
-  )
-    return true; // metamask reject
-  if (
-    error.message ===
-    '​Error: TransportStatusError: Ledger device: Condition of use not satisfied (denied by the user?) (0x6985)'
+    error.message.includes(
+      'Ledger device: Condition of use not satisfied (denied by the user?)'
+    ) &&
+    error.code === -32603
   )
     return true; // ledger reject via metamask
+  if (error.message.includes('​Ledger device: U2F OTHER_ERROR')) return false; // ledger time-out or no-connect via metamask
+  if (error.message.includes('User denied transaction signature.')) return true; // portis
   if (
-    error.message ===
-    '​Error: TransportError: Failed to sign with Ledger device: U2F OTHER_ERROR'
-  )
-    return false; // ledger time-out or no-connect via metamask
-  if (error.message === 'User denied transaction signature.') return true; // portis
-  if (
-    error.message ===
-    'Fortmatic RPC Error: [-32603] Fortmatic: User denied transaction.'
+    error.message.includes(
+      'Fortmatic RPC Error: [-32603] Fortmatic: User denied transaction.'
+    )
   )
     return true;
 

--- a/src/pages/Transactions/transactionUtils.tsx
+++ b/src/pages/Transactions/transactionUtils.tsx
@@ -33,17 +33,17 @@ const isUserRejectionError = (error: any) => {
       return true;
     // 3. Trezor reject via Metamask
     if (error.message.includes('Error: Action cancelled by user')) return true;
-    // 3. Trezor popup closed via Metamask
+    // 4. Trezor popup closed via Metamask
     if (error.message.includes('Error: Popup closed')) return true;
-    // 3. Trezor popup denied via Metamask
+    // 5. Trezor popup denied via Metamask
     if (error.message.includes('Error: Permissions not granted')) return true;
-    // 3. Trezor disconnected via Metamask
+    // 6. Trezor disconnected via Metamask
     if (error.message.includes('Error: device disconnected during action'))
       return true;
-    // 4. Fortmatic reject
+    // 7. Fortmatic reject
     if (error.message.includes('Fortmatic: User denied transaction.'))
       return true;
-    // 5. Portis Reject
+    // 8. Portis Reject
     if (error.message.includes('User denied transaction signature.'))
       return true;
   }

--- a/src/pages/Transactions/transactionUtils.tsx
+++ b/src/pages/Transactions/transactionUtils.tsx
@@ -32,13 +32,13 @@ const isUserRejectionError = (error: any) => {
     )
       return true;
     // 3. Trezor reject via Metamask
-    if (error.message.includes('Error: Action cancelled by user')) return true;
+    if (error.message.includes('Action cancelled by user')) return true;
     // 4. Trezor popup closed via Metamask
-    if (error.message.includes('Error: Popup closed')) return true;
+    if (error.message.includes('Popup closed')) return true;
     // 5. Trezor popup denied via Metamask
-    if (error.message.includes('Error: Permissions not granted')) return true;
+    if (error.message.includes('Permissions not granted')) return true;
     // 6. Trezor disconnected via Metamask
-    if (error.message.includes('Error: device disconnected during action'))
+    if (error.message.includes('device disconnected during action'))
       return true;
     // 7. Fortmatic reject
     if (error.message.includes('Fortmatic: User denied transaction.'))


### PR DESCRIPTION
If a user takes too long to sign a deposit on their HW wallet, or they accidentally reject it on their HW wallet, Metamask returns a different error, this handles those cases. Addresses #279