### PR TITLE
Makes deposit command compatible with all shells.

### DIFF
--- a/src/pages/GenerateKeys/Option1.tsx
+++ b/src/pages/GenerateKeys/Option1.tsx
@@ -94,7 +94,7 @@ export const Option1 = ({
           )}
           {os === 'windows' && (
             <>
-              <span style={{ color: colors.red.medium }}>deposit</span>
+              <span style={{ color: colors.red.medium }}>.\deposit</span>
               <span style={{ color: colors.purple.dark }}>.exe </span>
             </>
           )}


### PR DESCRIPTION
Some shells (notably Powershell on Windows) require a leading `.\` when executing something from the current directory.  This also ensures that if the user has some globally installed `deposit` binary on their machine that won't be used and only the `deposit` file in the current directory will be or the command will fail (a good thing in this case).