### PR TITLE
Removed duplicated word typo

### DIFF
--- a/src/pages/Checklist/index.tsx
+++ b/src/pages/Checklist/index.tsx
@@ -546,7 +546,7 @@ export const Checklist = () => {
         <section>
           <Heading level={3}>Simulations</Heading>
           <Heading level={4}>
-            The following are are recommended simulations for ensuring your
+            The following are recommended simulations for ensuring your
             validation setup is robust:
           </Heading>
           <CheckBox


### PR DESCRIPTION
Small typo correction on the checklist page (`are are`): 
![image](https://user-images.githubusercontent.com/54227730/104155593-66d26480-539c-11eb-88a4-db167495e245.png)
Simple correction.
