### PR TITLE
Language path adjustments

### DIFF
--- a/src/components/LocalizedRouter.tsx
+++ b/src/components/LocalizedRouter.tsx
@@ -24,7 +24,7 @@ export const LocalizedRouter: React.FC<Props> = ({ children, history }) => (
          * If language is not in route path, redirect to language route
          */
         const { pathname } = location;
-        if (!pathname.includes(`/${lang}/`)) {
+        if (!pathname.includes(`/${lang}/`) && pathname !== `/${lang}`) {
           return <Redirect to={`/${lang}${pathname}`} />;
         }
 

--- a/src/components/LocalizedRouter.tsx
+++ b/src/components/LocalizedRouter.tsx
@@ -3,7 +3,8 @@ import { Router } from 'react-router-dom';
 
 import { IntlProvider } from 'react-intl';
 import { Route, Redirect } from 'react-router-dom';
-import { messages, AppLanguage } from '../intl';
+import { messages, AppLanguage, supportedLanguages } from '../intl';
+import { routesEnum } from '../Routes';
 
 interface Props {
   history: any;
@@ -19,6 +20,13 @@ export const LocalizedRouter: React.FC<Props> = ({ children, history }) => (
          */
         const params = match ? match.params : {};
         const { lang = AppLanguage.English } = params;
+
+        /**
+         * If language provided is not supported, redirect to "languages" page
+         */
+        if (supportedLanguages.indexOf(lang) < 0) {
+          return <Redirect push to={routesEnum.languagesPage} />;
+        }
 
         /**
          * If language is not in route path, redirect to language route

--- a/src/pages/Languages/index.tsx
+++ b/src/pages/Languages/index.tsx
@@ -89,9 +89,9 @@ export const Languages = () => {
   return (
     <PageTemplate title="Choose a language">
       <LangContainer>
-        {langs.map(lang => {
+        {langs.map((lang, idx) => {
           return (
-            <LangItem to={lang.path}>
+            <LangItem key={String(idx)} to={lang.path}>
               <ContentContainer>
                 <LangTitle>{lang.language}</LangTitle>
                 <Lang>{lang.title}</Lang>
@@ -100,10 +100,10 @@ export const Languages = () => {
           );
         })}
       </LangContainer>
-      <text>
+      <p>
         If you'd like to see the launchpad in another language, or if you can
         help translate, get in touch.
-      </text>
+      </p>
     </PageTemplate>
   );
 };


### PR DESCRIPTION
- Prevents `/en` from redirecting to `/en/en`
- If no two-letter language code, will default to `/en/`
- If two-letter code not supported, will redirect to `/en/lanagues` to select a supported language
- Cleaned up a couple console warnings (.map key/idx, and `<text>` -> `<p>`)