### PR TITLE
Add Crowdin text extraction format

### DIFF
--- a/package.json
+++ b/package.json
@@ -104,7 +104,7 @@
     "build": "rescripts build",
     "test": "rescripts test",
     "eject": "rescripts eject",
-    "extract": "formatjs extract 'src/**/*.{t,j}sx' --out-file src/intl/en.json --id-interpolation-pattern '[sha512:contenthash:base64:6]'"
+    "extract": "formatjs extract 'src/**/*.{t,j}sx' --out-file src/intl/en.json --id-interpolation-pattern '[sha512:contenthash:base64:6]' --format crowdin"
   },
   "eslintConfig": {
     "extends": "react-app"

--- a/src/intl/en.json
+++ b/src/intl/en.json
@@ -1,128 +1,129 @@
 {
   "+UUcBt": {
-    "defaultMessage": "Choose a language"
+    "message": "Choose a language"
   },
   "/SbhtD": {
-    "defaultMessage": "You can also use {homebrew} to install pip3. For the most-up-to-date instructions on installing pip3, and for a direct download link, reference the {docs}"
-  },
-  "0ANoM/": {
-    "defaultMessage": "{directoriesPattern} will find {keyDirectory}, and expect to find {passwordDirectory}."
+    "message": "You can also use {homebrew} to install pip3. For the most-up-to-date instructions on installing pip3, and for a direct download link, reference the {docs}"
   },
   "1utfoI": {
-    "defaultMessage": "Use {mainnet} to sync the Ethereum mainnet."
+    "message": "Use {mainnet} to sync the Ethereum mainnet."
   },
   "2pTHr8": {
-    "defaultMessage": "You can install python3 on your MacOS device using {homebrew}"
+    "message": "You can install python3 on your MacOS device using {homebrew}"
   },
   "2t/3ab": {
-    "defaultMessage": "The other file you just generated is {depositDataJson}. This file contains the public key(s) associated with your validator(s); You will need to upload this in the next step."
+    "message": "The other file you just generated is {depositDataJson}. This file contains the public key(s) associated with your validator(s); You will need to upload this in the next step."
   },
   "594ZNn": {
-    "defaultMessage": "This json file isn't for the right network. Upload a file generated for your current network: {network}."
+    "message": "This json file isn't for the right network. Upload a file generated for your current network: {network}."
   },
   "7Jo6ZP": {
-    "defaultMessage": "Please make sure that you are downloading from the official Ethereum Foundation GitHub account by verifying the url: {url}"
+    "message": "Please make sure that you are downloading from the official Ethereum Foundation GitHub account by verifying the url: {url}"
   },
   "7KqQZV": {
-    "defaultMessage": "Language Support"
+    "message": "Language Support"
   },
   "8WtyrD": {
-    "defaultMessage": "Spanish"
+    "message": "Spanish"
   },
   "9lBMQr": {
-    "defaultMessage": "{keyFile} of paths via the {validatorsKeys} option."
+    "message": "{keyFile} of paths via the {validatorsKeys} option."
   },
   "Bs34de": {
-    "defaultMessage": "The path separator is operating system dependent, and should be {semicolon} in Windows rather than {colon}."
+    "message": "The path separator is operating system dependent, and should be {semicolon} in Windows rather than {colon}."
   },
   "C1XY1c": {
-    "defaultMessage": "Choose {ethereum} client"
+    "message": "Choose {ethereum} client"
   },
   "CACPC+": {
-    "defaultMessage": "Czech"
+    "message": "Czech"
   },
   "E+Y27g": {
-    "defaultMessage": "You can check your Python version by typing {terminalCommand} in your terminal."
+    "message": "You can check your Python version by typing {terminalCommand} in your terminal."
   },
   "HDgppg": {
-    "defaultMessage": "You can install pip using a Linux Package Manager like {apt} or {yum}."
+    "message": "You can install pip using a Linux Package Manager like {apt} or {yum}."
   },
   "HkjkaV": {
-    "defaultMessage": "{depositFileName} isn't a valid deposit_data json file. Try again."
+    "message": "{depositFileName} isn't a valid deposit_data json file. Try again."
   },
   "J455S4": {
-    "defaultMessage": "If you’re a git user, you can run {gitClone} to download the {master} branch."
+    "message": "If you’re a git user, you can run {gitClone} to download the {master} branch."
   },
   "J5Lzz1": {
-    "defaultMessage": "Chinese (traditional)"
+    "message": "Chinese (traditional)"
   },
   "JUye/m": {
-    "defaultMessage": "Use the terminal to move into the directory that contains the {deposit} executable"
+    "message": "Use the terminal to move into the directory that contains the {deposit} executable"
   },
   "JYvwX8": {
-    "defaultMessage": "{filesPattern} will expect that the {keyFile} exists, and the file containing the password for it is {passwordFile}."
+    "message": "{filesPattern} will expect that the {keyFile} exists, and the file containing the password for it is {passwordFile}."
   },
   "LeHQQm": {
-    "defaultMessage": "Validator FAQs"
+    "message": "Validator FAQs"
   },
   "NEmnAV": {
-    "defaultMessage": "Italian"
+    "message": "Italian"
   },
   "Px7wWb": {
-    "defaultMessage": "pip documentation"
+    "message": "pip documentation"
   },
   "VPpHAq": {
-    "defaultMessage": "I understand that I {cannotTransfer} my stake for a while, and I {cannotWithdraw} until the merge. I understand that if I exit, I will not be able to rejoin until much later. This is a long term commitment."
+    "message": "I understand that I {cannotTransfer} my stake for a while, and I {cannotWithdraw} until the merge. I understand that if I exit, I will not be able to rejoin until much later. This is a long term commitment."
   },
   "WkrNSk": {
-    "defaultMessage": "English"
+    "message": "English"
   },
   "YBs4dR": {
-    "defaultMessage": "The latest version of pip should have been installed with python 3.x.x. For more information about installing pip on Windows, visit {windowsInstallGuide}. Or you can install the pip package via {chocolatey}."
+    "message": "The latest version of pip should have been installed with python 3.x.x. For more information about installing pip on Windows, visit {windowsInstallGuide}. Or you can install the pip package via {chocolatey}."
   },
   "Z07LQm": {
-    "defaultMessage": "Couldn't upload {depositFileName} due to an error. Open an issue in GitHub so we can investigate."
+    "message": "Couldn't upload {depositFileName} due to an error. Open an issue in GitHub so we can investigate."
   },
   "aziK5i": {
-    "defaultMessage": "Use {http} to connect your Eth2 node to the JSON RPC endpoint. This will enable the JSON RPC services on the default 8545 port."
+    "message": "Use {http} to connect your Eth2 node to the JSON RPC endpoint. This will enable the JSON RPC services on the default 8545 port."
   },
   "gN9D/h": {
-    "defaultMessage": "Use {goerli} to sync the Goerli testnet."
+    "message": "Use {goerli} to sync the Goerli testnet."
   },
   "iDXMFo": {
-    "defaultMessage": "Answers to common questions on becomming a validator."
+    "message": "Answers to common questions on becomming a validator."
   },
   "jyN21A": {
-    "defaultMessage": "Eth2 Launchpad"
+    "message": "Eth2 Launchpad"
   },
   "krEziQ": {
-    "defaultMessage": "Get in touch"
+    "message": "Get in touch"
   },
   "lVdzDK": {
-    "defaultMessage": "Upload the deposit data file you just generated. The {json} is located in your {validatorKeys} directory."
+    "message": "Upload the deposit data file you just generated. The {json} is located in your {validatorKeys} directory."
+  },
+  "m4GjWu": {
+    "description": "{directoriesPattern} refers to a computer command which will find {keyDirectory} and {passwordDirectory} - both folders within a computer.",
+    "message": "{directoriesPattern} will find {keyDirectory}, and expect to find {passwordDirectory}."
   },
   "pA+UVF": {
-    "defaultMessage": "If you'd like to see the launchpad in another language, or if you can help translate, {getInTouch}!"
+    "message": "If you'd like to see the launchpad in another language, or if you can help translate, {getInTouch}!"
   },
   "qDvaNm": {
-    "defaultMessage": "I understand that keys are my responsibility and that my mnemonic (seed) will be the {onlyWay} to withdraw my funds."
+    "message": "I understand that keys are my responsibility and that my mnemonic (seed) will be the {onlyWay} to withdraw my funds."
   },
   "qQ+Xla": {
-    "defaultMessage": "Korean"
+    "message": "Korean"
   },
   "ujVT29": {
-    "defaultMessage": "You should now have your mnemonic written down in a safe place and a keystore saved for each of your {validatorCount} validators. Please make sure you keep these safe, preferably offline. Your validator keystores should be available in the newly created {validatorKeys} directory."
+    "message": "You should now have your mnemonic written down in a safe place and a keystore saved for each of your {validatorCount} validators. Please make sure you keep these safe, preferably offline. Your validator keystores should be available in the newly created {validatorKeys} directory."
   },
   "uq7E+F": {
-    "defaultMessage": "Please make sure you have set {flag} for {network}, otherwise the deposit will be invalid."
+    "message": "Please make sure you have set {flag} for {network}, otherwise the deposit will be invalid."
   },
   "vFrE9m": {
-    "defaultMessage": "Become a validator and help secure Eth2."
+    "message": "Become a validator and help secure Eth2."
   },
   "vYOWYI": {
-    "defaultMessage": "Chinese (simplified)"
+    "message": "Chinese (simplified)"
   },
   "z/ZhML": {
-    "defaultMessage": "Make sure you have set {flag} for {network}, otherwise the deposit will be invalid."
+    "message": "Make sure you have set {flag} for {network}, otherwise the deposit will be invalid."
   }
 }

--- a/src/intl/en.json
+++ b/src/intl/en.json
@@ -1,9 +1,33 @@
 {
+  "+UUcBt": {
+    "defaultMessage": "Choose a language"
+  },
+  "/SbhtD": {
+    "defaultMessage": "You can also use {homebrew} to install pip3. For the most-up-to-date instructions on installing pip3, and for a direct download link, reference the {docs}"
+  },
   "0ANoM/": {
     "defaultMessage": "{directoriesPattern} will find {keyDirectory}, and expect to find {passwordDirectory}."
   },
   "1utfoI": {
     "defaultMessage": "Use {mainnet} to sync the Ethereum mainnet."
+  },
+  "2pTHr8": {
+    "defaultMessage": "You can install python3 on your MacOS device using {homebrew}"
+  },
+  "2t/3ab": {
+    "defaultMessage": "The other file you just generated is {depositDataJson}. This file contains the public key(s) associated with your validator(s); You will need to upload this in the next step."
+  },
+  "594ZNn": {
+    "defaultMessage": "This json file isn't for the right network. Upload a file generated for your current network: {network}."
+  },
+  "7Jo6ZP": {
+    "defaultMessage": "Please make sure that you are downloading from the official Ethereum Foundation GitHub account by verifying the url: {url}"
+  },
+  "7KqQZV": {
+    "defaultMessage": "Language Support"
+  },
+  "8WtyrD": {
+    "defaultMessage": "Spanish"
   },
   "9lBMQr": {
     "defaultMessage": "{keyFile} of paths via the {validatorsKeys} option."
@@ -14,42 +38,56 @@
   "C1XY1c": {
     "defaultMessage": "Choose {ethereum} client"
   },
-  "JYvwX8": {
-    "defaultMessage": "{filesPattern} will expect that the {keyFile} exists, and the file containing the password for it is {passwordFile}."
-  },
-  "+UUcBt": {
-    "defaultMessage": "Choose a language"
-  },
-  "7KqQZV": {
-    "defaultMessage": "Language Support"
-  },
-  "8WtyrD": {
-    "defaultMessage": "Spanish"
-  },
   "CACPC+": {
     "defaultMessage": "Czech"
+  },
+  "E+Y27g": {
+    "defaultMessage": "You can check your Python version by typing {terminalCommand} in your terminal."
+  },
+  "HDgppg": {
+    "defaultMessage": "You can install pip using a Linux Package Manager like {apt} or {yum}."
+  },
+  "HkjkaV": {
+    "defaultMessage": "{depositFileName} isn't a valid deposit_data json file. Try again."
+  },
+  "J455S4": {
+    "defaultMessage": "If you’re a git user, you can run {gitClone} to download the {master} branch."
   },
   "J5Lzz1": {
     "defaultMessage": "Chinese (traditional)"
   },
+  "JUye/m": {
+    "defaultMessage": "Use the terminal to move into the directory that contains the {deposit} executable"
+  },
+  "JYvwX8": {
+    "defaultMessage": "{filesPattern} will expect that the {keyFile} exists, and the file containing the password for it is {passwordFile}."
+  },
   "LeHQQm": {
     "defaultMessage": "Validator FAQs"
-  },
-  "aziK5i": {
-    "defaultMessage": "Use {http} to connect your Eth2 node to the JSON RPC endpoint. This will enable the JSON RPC services on the default 8545 port."
-  },
-  "eSWhUt": {
-    "defaultMessage": "Hello, {name}!",
-    "description": "Greeting to welcome the user to the app"
-  },
-  "gN9D/h": {
-    "defaultMessage": "Use {goerli} to sync the Goerli testnet."
   },
   "NEmnAV": {
     "defaultMessage": "Italian"
   },
+  "Px7wWb": {
+    "defaultMessage": "pip documentation"
+  },
+  "VPpHAq": {
+    "defaultMessage": "I understand that I {cannotTransfer} my stake for a while, and I {cannotWithdraw} until the merge. I understand that if I exit, I will not be able to rejoin until much later. This is a long term commitment."
+  },
   "WkrNSk": {
     "defaultMessage": "English"
+  },
+  "YBs4dR": {
+    "defaultMessage": "The latest version of pip should have been installed with python 3.x.x. For more information about installing pip on Windows, visit {windowsInstallGuide}. Or you can install the pip package via {chocolatey}."
+  },
+  "Z07LQm": {
+    "defaultMessage": "Couldn't upload {depositFileName} due to an error. Open an issue in GitHub so we can investigate."
+  },
+  "aziK5i": {
+    "defaultMessage": "Use {http} to connect your Eth2 node to the JSON RPC endpoint. This will enable the JSON RPC services on the default 8545 port."
+  },
+  "gN9D/h": {
+    "defaultMessage": "Use {goerli} to sync the Goerli testnet."
   },
   "iDXMFo": {
     "defaultMessage": "Answers to common questions on becomming a validator."
@@ -60,16 +98,31 @@
   "krEziQ": {
     "defaultMessage": "Get in touch"
   },
+  "lVdzDK": {
+    "defaultMessage": "Upload the deposit data file you just generated. The {json} is located in your {validatorKeys} directory."
+  },
   "pA+UVF": {
     "defaultMessage": "If you'd like to see the launchpad in another language, or if you can help translate, {getInTouch}!"
   },
+  "qDvaNm": {
+    "defaultMessage": "I understand that keys are my responsibility and that my mnemonic (seed) will be the {onlyWay} to withdraw my funds."
+  },
   "qQ+Xla": {
     "defaultMessage": "Korean"
+  },
+  "ujVT29": {
+    "defaultMessage": "You should now have your mnemonic written down in a safe place and a keystore saved for each of your {validatorCount} validators. Please make sure you keep these safe, preferably offline. Your validator keystores should be available in the newly created {validatorKeys} directory."
+  },
+  "uq7E+F": {
+    "defaultMessage": "Please make sure you have set {flag} for {network}, otherwise the deposit will be invalid."
   },
   "vFrE9m": {
     "defaultMessage": "Become a validator and help secure Eth2."
   },
   "vYOWYI": {
     "defaultMessage": "Chinese (simplified)"
+  },
+  "z/ZhML": {
+    "defaultMessage": "Make sure you have set {flag} for {network}, otherwise the deposit will be invalid."
   }
 }

--- a/src/pages/Clients/Eth2/Teku.tsx
+++ b/src/pages/Clients/Eth2/Teku.tsx
@@ -146,6 +146,7 @@ export const TekuDetails = ({ shortened }: { shortened?: boolean }) => (
           <Text>
             <FormattedMessage
               defaultMessage="{directoriesPattern} will find {keyDirectory}, and expect to find {passwordDirectory}."
+              description="{directoriesPattern} refers to a computer command which will find {keyDirectory} and {passwordDirectory} - both folders within a computer."
               values={{
                 directoriesPattern: (
                   <Code className="px5 ml5">
@@ -166,6 +167,7 @@ export const TekuDetails = ({ shortened }: { shortened?: boolean }) => (
             />{' '}
             <FormattedMessage
               defaultMessage="{filesPattern} will expect that the {keyFile} exists, and the file containing the password for it is {passwordFile}."
+              description="{filesPattern} refers to a computer command which will find {keyFile} and {passwordFile} - both files within a computer."
               values={{
                 filesPattern: (
                   <Code className="px5 ml5">
@@ -186,6 +188,7 @@ export const TekuDetails = ({ shortened }: { shortened?: boolean }) => (
             />{' '}
             <FormattedMessage
               defaultMessage="The path separator is operating system dependent, and should be {semicolon} in Windows rather than {colon}."
+              description="The {semicolon} and {colon} variables refer to the keyboard characters ';' and ':'."
               values={{
                 semicolon: <Code className="px5 ml5">;</Code>,
                 colon: <Code className="px5 ml5">:</Code>,


### PR DESCRIPTION
@ryancreatescopy @wackerow @sorumfactory - good news. The `react-intl` supports automatic text extraction & can output into a [JSON format that plays nice with Crowdin](https://formatjs.io/docs/getting-started/message-extraction#translation-management-system-tms-integration).

The JSON format looks like this:
```
  "25suT4": {
    "description": "The {semicolon} and {colon} variables refer to the keyboard characters ';' and ':'.",
    "message": "The path separator is operating system dependent, and should be {semicolon} in Windows rather than {colon}."
  },
```

I've tested this out by uploading our `en.json` file into a test Crowdin project:
https://crowdin.com/project/eth2-launchpad-test

Now we can use variables and provide descriptions of the phrases directly in the code, e.g. in `Teku.txs`:
```
            <FormattedMessage
              defaultMessage="The path separator is operating system dependent, and should be {semicolon} in Windows rather than {colon}."
              description="The {semicolon} and {colon} variables refer to the keyboard characters ';' and ':'."
              values={{
                semicolon: <Code className="px5 ml5">;</Code>,
                colon: <Code className="px5 ml5">:</Code>,
              }}
            />
```

This allows us to use custom HTML elements within sentences to format the content:
![Image 2021-02-04 at 4 36 48 PM](https://user-images.githubusercontent.com/8097623/106973190-3cf42f80-6707-11eb-8fd7-933a9be48d39.jpg)


When the translator looks within Crowdin to translate, they would see the `<FormattedMessage />` above as:
![Image 2021-02-04 at 4 40 10 PM](https://user-images.githubusercontent.com/8097623/106973568-f18e5100-6707-11eb-9828-8f887f787604.jpg)

Hopefully these "descriptions" will add helpful context to our translators, particular when it comes to technical terms!