### PR TITLE
Connect wallet updates

### DIFF
--- a/src/components/AppBar.tsx
+++ b/src/components/AppBar.tsx
@@ -20,6 +20,7 @@ import { routesEnum } from '../Routes';
 import { Heading } from './Heading';
 import { ETH2_NETWORK_NAME, IS_MAINNET } from '../utils/envVars';
 import useMobileCheck from '../hooks/useMobileCheck';
+import { FormattedMessage } from 'react-intl';
 
 const RainbowBackground = styled(Box)`
   background-image: ${p => `linear-gradient(to right, ${p.theme.rainbow})`};
@@ -56,6 +57,18 @@ const ValidatorDropdown = styled(DropButton)`
   :hover {
     border: none;
     box-shadow: none;
+  }
+`;
+
+const DotDropdown = styled(DropButton)`
+  display: flex;
+  align-items: center;
+  border: none;
+  padding: 0;
+  margin: 0;
+  :hover {
+    transition: transform 0.2s;
+    transform: scale(1.1);
   }
 `;
 
@@ -116,6 +129,8 @@ const _AppBar = ({ location }: RouteComponentProps) => {
 
   const mobile = useMobileCheck('1080px');
 
+  const networkName = IS_MAINNET ? 'Mainnet' : 'Göerli Testnet';
+
   return (
     <RainbowBackground
       tag="header"
@@ -155,14 +170,14 @@ const _AppBar = ({ location }: RouteComponentProps) => {
             className="bar-link-text"
             active={pathname === routesEnum.acknowledgementPage}
           >
-            Deposit
+            <FormattedMessage defaultMessage="Deposit" />
           </BarLinkText>
         </Link>
         <ValidatorDropdown
           className="secondary-link"
           label={
             <BarLinkText level={4} margin="none" active={isDropdownPage}>
-              Clients
+              <FormattedMessage defaultMessage="Clients" />
             </BarLinkText>
           }
           dropAlign={{ top: 'bottom', right: 'right' }}
@@ -182,7 +197,7 @@ const _AppBar = ({ location }: RouteComponentProps) => {
             className="bar-link-text"
             active={pathname === routesEnum.checklistPage}
           >
-            Checklist
+            <FormattedMessage defaultMessage="Checklist" />
           </BarLinkText>
         </Link>
         <Link to={routesEnum.FaqPage} className="mx10 secondary-link">
@@ -192,7 +207,7 @@ const _AppBar = ({ location }: RouteComponentProps) => {
             className="bar-link-text"
             active={pathname === routesEnum.FaqPage}
           >
-            FAQ
+            <FormattedMessage defaultMessage="FAQ" />
           </BarLinkText>
         </Link>
       </NavBarLinks>
@@ -205,7 +220,7 @@ const _AppBar = ({ location }: RouteComponentProps) => {
               className="bar-link-text"
               active={pathname === routesEnum.languagesPage}
             >
-              Languages
+              <FormattedMessage defaultMessage="Languages" />
             </BarLinkText>
           </Link>
         )}
@@ -235,21 +250,25 @@ const _AppBar = ({ location }: RouteComponentProps) => {
                     {IS_MAINNET ? `` : ` Testnet`}
                   </NetworkText>
                   <Text className="mt20">
-                    <em>Visit this site on desktop to become a validator.</em>
+                    <em>
+                      <FormattedMessage defaultMessage="Visit this site on desktop to become a validator." />
+                    </em>
                   </Text>
                 </NetworkInfo>
                 <Box pad="medium" className="mt0">
                   <DropdownLink to={routesEnum.FaqPage}>
-                    Frequently asked questions
+                    <FormattedMessage defaultMessage="FAQ" />
                   </DropdownLink>
                   <DropdownLink to={routesEnum.checklistPage}>
-                    Eth2 staker checklist
+                    <FormattedMessage defaultMessage="Staker checklist" />
                   </DropdownLink>
                   <DropdownLink to={routesEnum.languagesPage}>
-                    Languages
+                    <FormattedMessage defaultMessage="Languages" />
                   </DropdownLink>
                   <Text className="my20">
-                    <b>The Eth2 clients</b>
+                    <b>
+                      <FormattedMessage defaultMessage="The Eth2 clients" />
+                    </b>
                   </Text>
                   <DropdownLink to={routesEnum.lighthouse}>
                     Lighthouse
@@ -269,8 +288,40 @@ const _AppBar = ({ location }: RouteComponentProps) => {
           </NetworkText>
         )}
         {!mobile && walletConnected && (
-          <Box className="flex flex-row mr20" style={{ paddingTop: 8 }}>
-            <Dot success={networkAllowed} error={!networkAllowed} />
+          <Box className="flex flex-row mr20">
+            {networkAllowed && (
+              <DotDropdown
+                className="secondary-link"
+                label={<Dot success={networkAllowed} error={!networkAllowed} />}
+                dropAlign={{ top: 'bottom', right: 'right' }}
+                dropContent={
+                  <Box pad="small">
+                    <Text>
+                      <FormattedMessage defaultMessage="You're on the right network!" />
+                    </Text>
+                  </Box>
+                }
+              />
+            )}
+            {!networkAllowed && (
+              <DotDropdown
+                className="secondary-link"
+                label={<Dot error={!networkAllowed} />}
+                dropAlign={{ top: 'bottom', right: 'right' }}
+                dropContent={
+                  <Box pad="small">
+                    <Text>
+                      <FormattedMessage
+                        defaultMessage="Your wallet should be set to {networkName} to use this launchpad."
+                        values={{
+                          networkName: <span>{networkName}</span>,
+                        }}
+                      />
+                    </Text>
+                  </Box>
+                }
+              />
+            )}
             <Text size="small" className="ml10" color="blueDark">
               {trimString(account as string, 10)}
             </Text>

--- a/src/components/Dot.tsx
+++ b/src/components/Dot.tsx
@@ -1,5 +1,7 @@
 import React from 'react';
 import styled from 'styled-components';
+import { Checkmark } from 'grommet-icons';
+import { Close } from 'grommet-icons';
 
 interface DotProps {
   theme?: any;
@@ -13,18 +15,21 @@ interface DotProps {
 const StyledDiv = styled.div`
   width: ${(p: DotProps) => p.width || 20}px;
   height: ${(p: DotProps) => p.height || 20}px;
+  padding: 8px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
   background: ${(p: DotProps) => {
     if (p.success) return p.theme.green.dark;
     if (p.error) return p.theme.red.medium;
     return p.theme.gray.light;
   }};
-  border: 3px solid
-    ${(p: DotProps) => {
-      if (p.success) return p.theme.green.medium;
-      if (p.error) return p.theme.red.light;
-      return p.theme.gray.medium;
-    }};
   border-radius: 50%;
 `;
 
-export const Dot = (props: DotProps) => <StyledDiv {...props} />;
+export const Dot = (props: DotProps) => (
+  <StyledDiv {...props}>
+    {props.success && <Checkmark size="small" color="white" />}
+    {!props.success && <Close size="small" color="white" />}
+  </StyledDiv>
+);

--- a/src/pages/ConnectWallet/MetamaskHardwareButton.tsx
+++ b/src/pages/ConnectWallet/MetamaskHardwareButton.tsx
@@ -4,22 +4,28 @@ import ledger from '../../static/ledger.png';
 import { Paper } from '../../components/Paper';
 import { Text } from '../../components/Text';
 import { Link } from '../../components/Link';
+import { FormattedMessage } from 'react-intl';
 
 const Logo = styled.img`
   height: 50px;
   width: 50px;
   display: block;
-  margin: 10px;
+  margin: 24px;
 `;
 
 const StyledText = styled(Text)`
-  margin: auto;
+  margin: 10px;
   font-size: 14px;
-  text-align: center;
 `;
 const StyledPaper = styled(Paper)`
   width: 350px;
   margin: 10px;
+  align-items: center;
+  &:hover {
+    box-shadow: 0px 8px 17px rgba(0, 0, 0, 0.15);
+    transition: transform 0.1s;
+    transform: scale(1.02);
+  }
 `;
 
 export const MetamaskHardwareButton = () => {
@@ -31,8 +37,9 @@ export const MetamaskHardwareButton = () => {
       >
         <Logo src={ledger} />
         <StyledText>
-          Learn how to connect your hardware device on Metamask
+          <FormattedMessage defaultMessage="Connect your hardware wallet to Metamask" />
         </StyledText>
+        <StyledText className="mr20">↗</StyledText>
       </StyledPaper>
     </Link>
   );

--- a/src/pages/ConnectWallet/WalletButton.tsx
+++ b/src/pages/ConnectWallet/WalletButton.tsx
@@ -6,24 +6,45 @@ import { Web3Provider } from '@ethersproject/providers';
 import { AbstractConnector } from '@web3-react/abstract-connector';
 import { Paper } from '../../components/Paper';
 import { Text } from '../../components/Text';
+import { FormattedMessage } from 'react-intl';
 
 const Logo = styled.img`
   height: 50px;
   width: 50px;
   display: block;
-  margin: 10px;
+  margin: 24px;
 `;
 
 const StyledText = styled(Text)`
-  margin: auto;
+  margin: 10px;
   font-size: ${(p: { invalid?: boolean }) => (p.invalid ? '14px' : '24px')};
-  text-align: center;
 `;
+
 const StyledPaper = styled(Paper)`
   box-shadow: ${(p: { isActive: boolean }) =>
     p.isActive && `0 0 10px rgba(0, 0, 0, 0.5)`};
   width: 350px;
   margin: 10px;
+  align-items: center;
+  cursor: ${p => (p.error ? 'not-allowed' : 'pointer')};
+  &:hover {
+    box-shadow: ${p => (p.error ? 'none' : '0px 8px 17px rgba(0, 0, 0, 0.15)')};
+    transition: ${p => (p.error ? 'none' : 'transform 0.1s;')};
+    transform: ${p => (p.error ? 'none' : 'scale(1.02)')};
+  }
+`;
+
+const WalletText = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+`;
+
+const ConnectingContainer = styled.div`
+  display: flex;
+  justify-content: space-between;
+  width: 100%;
+  margin: 8px;
 `;
 
 export const WalletButton = ({
@@ -65,20 +86,36 @@ export const WalletButton = ({
     <StyledPaper
       pad="xsmall"
       className="wallet-button flex flex-row relative"
+      error={invalid}
       onClick={() => {
         if (!invalid) handleClick();
       }}
       isActive={selectedWallet === walletProvider}
     >
       <Logo src={logoSource} />
-      <StyledText invalid={invalid}>
-        {`${title} ${invalid ? 'is not supported in offline mode.' : ''}`}
-      </StyledText>
-      {showSpinner && (
-        <span className="mt20 mr10">
-          <Spinning kind="pulse" />
-        </span>
-      )}
+      <ConnectingContainer>
+        <WalletText>
+          <StyledText invalid={invalid}>
+            {!invalid && <>{title}</>}
+            {invalid && (
+              <FormattedMessage
+                defaultMessage="{title} is not supported in offline mode."
+                values={{ title: <span>{title}</span> }}
+              />
+            )}
+          </StyledText>
+          {showSpinner && (
+            <Text className="ml10" size="small">
+              <FormattedMessage defaultMessage="Waiting to connect..." />
+            </Text>
+          )}
+        </WalletText>
+        {showSpinner && (
+          <span className="mt20 flex flex-row mr10">
+            <Spinning kind="pulse" />
+          </span>
+        )}
+      </ConnectingContainer>
     </StyledPaper>
   );
 };

--- a/src/pages/ConnectWallet/WalletDisconnected.tsx
+++ b/src/pages/ConnectWallet/WalletDisconnected.tsx
@@ -5,24 +5,42 @@ import { AcknowledgementSection } from '../Summary/AcknowledgementSection';
 import { Text } from '../../components/Text';
 import { routesEnum } from '../../Routes';
 import { Link as L } from '../../components/Link';
+import { FormattedMessage, useIntl } from 'react-intl';
 
 const Link = styled(L)`
   display: inline;
-  margin: 6px;
   text-decoration: underline !important;
   color: ${(p: { theme: any }) => p.theme.blueLight} !important;
 `;
 
-export const WalletDisconnected = () => (
-  <WorkflowPageTemplate title="Deposit summary">
-    <AcknowledgementSection title="Your wallet has disconnected">
-      <Text>
-        Your wallet has disconnected.
-        <Link to={routesEnum.connectWalletPage}>
-          Please connect your wallet
-        </Link>
-        and begin the deposit process again.
-      </Text>
-    </AcknowledgementSection>
-  </WorkflowPageTemplate>
-);
+export const WalletDisconnected = () => {
+  const { formatMessage } = useIntl();
+  const intl = useIntl();
+  const acknowledgementTitle = formatMessage({
+    defaultMessage: 'Your wallet has disconnected',
+  });
+
+  const pageTitle = formatMessage({
+    defaultMessage: 'Deposit summary',
+  });
+  return (
+    <WorkflowPageTemplate title={pageTitle}>
+      <AcknowledgementSection title={acknowledgementTitle}>
+        <Text>
+          <FormattedMessage
+            defaultMessage="To continue, {reconnect}"
+            values={{
+              reconnect: (
+                <Link to={routesEnum.connectWalletPage}>
+                  {intl.formatMessage({
+                    defaultMessage: 'reconnect your wallet',
+                  })}
+                </Link>
+              ),
+            }}
+          />
+        </Text>
+      </AcknowledgementSection>
+    </WorkflowPageTemplate>
+  );
+};

--- a/src/pages/ConnectWallet/WrongNetwork.tsx
+++ b/src/pages/ConnectWallet/WrongNetwork.tsx
@@ -3,16 +3,30 @@ import { AcknowledgementSection } from '../Summary/AcknowledgementSection';
 import { Text } from '../../components/Text';
 import { WorkflowPageTemplate } from '../../components/WorkflowPage/WorkflowPageTemplate';
 import { IS_MAINNET } from '../../utils/envVars';
+import { FormattedMessage, useIntl } from 'react-intl';
 
 const networkName = IS_MAINNET ? 'Mainnet' : 'Göerli Testnet';
 
-export const WrongNetwork = () => (
-  <WorkflowPageTemplate title="Deposit Summary">
-    <AcknowledgementSection title="Your network has changed">
-      <Text>
-        Your Ethereum network is not correct, Please connect to the{' '}
-        {networkName} network.
-      </Text>
-    </AcknowledgementSection>
-  </WorkflowPageTemplate>
-);
+export const WrongNetwork = () => {
+  const { formatMessage } = useIntl();
+  const acknowledgementTitle = formatMessage({
+    defaultMessage: 'Your network has changed',
+  });
+
+  const pageTitle = formatMessage({
+    defaultMessage: 'Deposit summary',
+  });
+  return (
+    <WorkflowPageTemplate title={pageTitle}>
+      <AcknowledgementSection title={acknowledgementTitle}>
+        <Text>
+          <FormattedMessage
+            defaultMessage="Your wallet is on the wrong Ethereum network. To continue, connect to the 
+            {networkName} network."
+            values={{ networkName: <span>{networkName}</span> }}
+          />
+        </Text>
+      </AcknowledgementSection>
+    </WorkflowPageTemplate>
+  );
+};

--- a/src/pages/ConnectWallet/index.tsx
+++ b/src/pages/ConnectWallet/index.tsx
@@ -198,6 +198,7 @@ const _ConnectWalletPage = ({
         error.message === 'Invariant failed: chainId 0xNaN is not an integer')
     );
   }, [error]);
+  const intl = useIntl();
 
   // setup RPC event listener
   const attemptedMMConnection: boolean = useMetamaskEagerConnect();
@@ -235,24 +236,6 @@ const _ConnectWalletPage = ({
     return '';
   };
 
-  const { formatMessage } = useIntl();
-
-  const pageTitle = formatMessage({
-    defaultMessage: 'Connect wallet',
-  });
-
-  const continueButton = formatMessage({
-    defaultMessage: 'Continue',
-  });
-
-  const connectButton = formatMessage({
-    defaultMessage: 'Connect new wallet',
-  });
-
-  const backButton = formatMessage({
-    defaultMessage: 'Back',
-  });
-
   // sets the status copy on provider or network change
   useEffect(() => {
     if (chainId) {
@@ -289,7 +272,9 @@ const _ConnectWalletPage = ({
   }
 
   return (
-    <WorkflowPageTemplate title={pageTitle}>
+    <WorkflowPageTemplate
+      title={intl.formatMessage({ defaultMessage: 'Connect wallet' })}
+    >
       <Container>
         <WalletConnectedContainer>
           <Animated
@@ -459,14 +444,18 @@ const _ConnectWalletPage = ({
       <ButtonRow>
         {!walletConnected && (
           <Link to={routesEnum.uploadValidatorPage}>
-            <Button className="mr10" width={100} label={backButton} />
+            <Button
+              className="mr10"
+              width={100}
+              label={intl.formatMessage({ defaultMessage: 'Back' })}
+            />
           </Link>
         )}
         {walletConnected && (
           <Button
             width={300}
             onClick={deactivate}
-            label={connectButton}
+            label={intl.formatMessage({ defaultMessage: 'Connect new wallet' })}
             className="mr10"
             color="blueDark"
           />
@@ -481,7 +470,7 @@ const _ConnectWalletPage = ({
               !networkAllowed ||
               lowBalance
             }
-            label={continueButton}
+            label={intl.formatMessage({ defaultMessage: 'Continue' })}
           />
         </Link>
       </ButtonRow>

--- a/src/pages/ConnectWallet/index.tsx
+++ b/src/pages/ConnectWallet/index.tsx
@@ -47,7 +47,7 @@ import {
 } from '../../utils/envVars';
 import { routeToCorrectWorkflowStep } from '../../utils/RouteToCorrectWorkflowStep';
 import { MetamaskHardwareButton } from './MetamaskHardwareButton';
-import { FormattedMessage } from 'react-intl';
+import { FormattedMessage, useIntl } from 'react-intl';
 
 // styled components
 const Container = styled.div`
@@ -235,6 +235,24 @@ const _ConnectWalletPage = ({
     return '';
   };
 
+  const { formatMessage } = useIntl();
+
+  const pageTitle = formatMessage({
+    defaultMessage: 'Connect wallet',
+  });
+
+  const continueButton = formatMessage({
+    defaultMessage: 'Continue',
+  });
+
+  const connectButton = formatMessage({
+    defaultMessage: 'Connect new wallet',
+  });
+
+  const backButton = formatMessage({
+    defaultMessage: 'Back',
+  });
+
   // sets the status copy on provider or network change
   useEffect(() => {
     if (chainId) {
@@ -271,7 +289,7 @@ const _ConnectWalletPage = ({
   }
 
   return (
-    <WorkflowPageTemplate title="Connect wallet">
+    <WorkflowPageTemplate title={pageTitle}>
       <Container>
         <WalletConnectedContainer>
           <Animated
@@ -441,14 +459,14 @@ const _ConnectWalletPage = ({
       <ButtonRow>
         {!walletConnected && (
           <Link to={routesEnum.uploadValidatorPage}>
-            <Button className="mr10" width={100} label="Back" />
+            <Button className="mr10" width={100} label={backButton} />
           </Link>
         )}
         {walletConnected && (
           <Button
             width={300}
             onClick={deactivate}
-            label="Connect a different wallet"
+            label={connectButton}
             className="mr10"
             color="blueDark"
           />
@@ -463,7 +481,7 @@ const _ConnectWalletPage = ({
               !networkAllowed ||
               lowBalance
             }
-            label="Continue"
+            label={continueButton}
           />
         </Link>
       </ButtonRow>

--- a/src/pages/ConnectWallet/index.tsx
+++ b/src/pages/ConnectWallet/index.tsx
@@ -251,12 +251,16 @@ const _ConnectWalletPage = ({
     ) {
       setStatus(`${balance} ${TICKER_NAME}`);
     } else if (walletConnected && error) {
-      setStatus('Error');
+      setStatus(intl.formatMessage({ defaultMessage: 'Error' }));
     } else if (!networkAllowed) {
       setStatus(
-        `Connect ${getWalletName(walletProvider)} to ${
-          IS_MAINNET ? 'Ethereum Mainnet' : 'Göerli Testnet'
-        }`
+        intl.formatMessage(
+          { defaultMessage: 'Connect {wallet} to {network}' },
+          {
+            wallet: getWalletName(walletProvider),
+            network: IS_MAINNET ? 'Ethereum Mainnet' : 'Göerli Testnet',
+          }
+        )
       );
     }
   }, [chainId, walletConnected, networkAllowed, error, balance, network]);
@@ -343,20 +347,18 @@ const _ConnectWalletPage = ({
                       <>
                         <FormattedMessage
                           defaultMessage="You do not have enough {eth} in this account for
-                          {depositKeys} {validator}"
+                          {numberOfValidators} {validator}"
                           values={{
-                            depositKeys: (
-                              <span>
-                                {depositKeys.length}
-                                {depositKeys.length > 1 ? 's' : ''}
-                              </span>
-                            ),
-                            eth: <span>{TICKER_NAME}</span>,
-                            validator: (
-                              <span>
-                                validator{depositKeys.length > 1 ? 's' : ''}
-                              </span>
-                            ),
+                            numberOfValidators: depositKeys.length,
+                            eth: TICKER_NAME,
+                            validator:
+                              depositKeys.length > 1
+                                ? intl.formatMessage({
+                                    defaultMessage: 'validators',
+                                  })
+                                : intl.formatMessage({
+                                    defaultMessage: 'validator',
+                                  }),
                           }}
                         />
                       </>
@@ -367,9 +369,9 @@ const _ConnectWalletPage = ({
                         primary
                       >
                         <FormattedMessage
-                          defaultMessage="Get {eth}"
+                          defaultMessage="Get {TICKER_NAME}"
                           values={{
-                            eth: <span>{TICKER_NAME}</span>,
+                            TICKER_NAME,
                           }}
                         />
                       </FaucetLink>

--- a/src/pages/ConnectWallet/index.tsx
+++ b/src/pages/ConnectWallet/index.tsx
@@ -11,8 +11,6 @@ import { UnsupportedChainIdError, useWeb3React } from '@web3-react/core';
 import { Web3Provider } from '@ethersproject/providers';
 import { formatEther } from '@ethersproject/units';
 import { NoEthereumProviderError } from '@web3-react/injected-connector';
-import { StatusWarning } from 'grommet-icons';
-import ReactTooltip from 'react-tooltip';
 import {
   AllowedNetworks,
   fortmatic,
@@ -49,19 +47,31 @@ import {
 } from '../../utils/envVars';
 import { routeToCorrectWorkflowStep } from '../../utils/RouteToCorrectWorkflowStep';
 import { MetamaskHardwareButton } from './MetamaskHardwareButton';
+import { FormattedMessage } from 'react-intl';
 
 // styled components
 const Container = styled.div`
   margin: auto;
   position: relative;
+  margin-bottom: 40px;
+  margin-top: 40px;
+  @media only screen and (max-width: ${p => p.theme.screenSizes.large}) {
+    margin-bottom: 0;
+  }
 `;
 const WalletConnectedContainer = styled.div`
   pointer-events: none;
-  width: 500px;
+  width: 800px;
   margin: auto;
   position: absolute;
-  left: calc(50% - 250px); // center - half width
+  left: calc(50% - 400px); // center - half width
+  @media only screen and (max-width: ${p => p.theme.screenSizes.large}) {
+    width: 100%;
+    left: 0;
+    height: 100%;
+  }
 `;
+
 const WalletButtonContainer = styled.div`
   margin: auto;
 `;
@@ -77,16 +87,56 @@ const WalletButtonSubContainer = styled.div`
 const WalletInfoContainer = styled.div`
   display: flex;
   justify-content: space-between;
+  align-items: center;
   border-bottom: 1px solid ${(p: { theme: any }) => p.theme.gray.medium};
   padding-bottom: 20px;
 `;
 const StatusText = styled(Text)`
-  font-size: 22px;
-  margin-left: 10px;
+  font-size: 18px;
 `;
 const FaucetLink = styled(Link)`
   margin: auto;
   margin-top: 10px;
+`;
+
+const Row = styled.div`
+  display: flex;
+  align-items: center;
+`;
+
+const Network = styled.div`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-top: 24px;
+`;
+
+const Balance = styled.div`
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-end;
+  margin-bottom: 16px;
+  margin-top: 24px;
+`;
+
+const ButtonRow = styled.div`
+  display: flex;
+  width: 100%;
+  justify-content: center;
+  margin-top: 128px;
+  @media only screen and (max-width: ${p => p.theme.screenSizes.large}) {
+    flex-direction: column;
+    align-items: center;
+  }
+`;
+
+const MetaMaskError = styled.div`
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  margin-top: 0px;
 `;
 
 export interface web3ReactInterface {
@@ -177,6 +227,14 @@ const _ConnectWalletPage = ({
     }
   }, [selectedWallet, walletProvider, library, chainId, depositKeys, account]);
 
+  const getWalletName = (provider?: AbstractConnector) => {
+    if (!provider) return '';
+    if (provider === metamask) return 'Metamask';
+    if (provider === portis) return 'Portis';
+    if (provider === fortmatic) return 'Fortmatic';
+    return '';
+  };
+
   // sets the status copy on provider or network change
   useEffect(() => {
     if (chainId) {
@@ -190,12 +248,12 @@ const _ConnectWalletPage = ({
       !error &&
       (balance || balance === 0)
     ) {
-      setStatus(`${balance} ${TICKER_NAME} available`);
+      setStatus(`${balance} ${TICKER_NAME}`);
     } else if (walletConnected && error) {
       setStatus('Error');
     } else if (!networkAllowed) {
       setStatus(
-        `Please connect to ${
+        `Connect ${getWalletName(walletProvider)} to ${
           IS_MAINNET ? 'Ethereum Mainnet' : 'Göerli Testnet'
         }`
       );
@@ -208,20 +266,12 @@ const _ConnectWalletPage = ({
     }
   };
 
-  const getWalletName = (provider?: AbstractConnector) => {
-    if (!provider) return '';
-    if (provider === metamask) return 'Metamask';
-    if (provider === portis) return 'Portis';
-    if (provider === fortmatic) return 'Fortmatic';
-    return '';
-  };
-
   if (workflow < WorkflowStep.CONNECT_WALLET) {
     return routeToCorrectWorkflowStep(workflow);
   }
 
   return (
-    <WorkflowPageTemplate title="Connect Wallet">
+    <WorkflowPageTemplate title="Connect wallet">
       <Container>
         <WalletConnectedContainer>
           <Animated
@@ -234,63 +284,95 @@ const _ConnectWalletPage = ({
           >
             <Paper pad="medium">
               <WalletInfoContainer>
-                <div className="flex">
+                <Heading level={3} size="small" color="blueDark">
+                  {getWalletName(walletProvider)}
+                </Heading>
+                {account && (
+                  <Text size="medium">
+                    {`${account.slice(0, 6)}...${account.slice(-6)}`}
+                  </Text>
+                )}
+              </WalletInfoContainer>
+              <Network>
+                <Row>
                   <Dot
-                    className="mt10"
+                    className="mr10"
                     success={networkAllowed}
                     error={!networkAllowed}
                   />
-                  <div className="ml20">
-                    <Heading
-                      level={3}
-                      size="small"
-                      color="blueDark"
-                      className="mt0"
-                    >
-                      {getWalletName(walletProvider)}
-                    </Heading>
-                    {account && (
-                      <Text size="small">
-                        {`${account.slice(0, 6)}...${account.slice(-6)}`}
-                      </Text>
-                    )}
-                  </div>
-                </div>
+                  <Heading
+                    level={3}
+                    size="small"
+                    color="blueDark"
+                    className="mt0"
+                  >
+                    <FormattedMessage defaultMessage="Network" />
+                  </Heading>
+                </Row>
                 <Text color={networkAllowed ? 'greenDark' : 'redMedium'}>
                   {network === 'Mainnet' ? network : `${network} Testnet`}
                 </Text>
-              </WalletInfoContainer>
-              <div className="flex center mt20">
-                {lowBalance && (
+              </Network>
+              <div>
+                {!networkAllowed && (
                   <>
-                    <ReactTooltip
-                      id="status-warning"
-                      type="warning"
-                      effect="solid"
-                    >
-                      <span>
-                        You do not have enough ETH in this wallet for{' '}
-                        {depositKeys.length} validator
-                        {depositKeys.length > 1 ? 's' : ''}
-                      </span>
-                    </ReactTooltip>
-                    <StatusWarning
-                      data-tip
-                      data-for="status-warning"
-                      color="yellowDark"
-                    />
+                    <StatusText className="mt10">{status}</StatusText>
                   </>
                 )}
-                <StatusText>{status}</StatusText>
               </div>
-              {!IS_MAINNET && lowBalance && (
-                <FaucetLink
-                  to="https://faucet.goerli.mudit.blog/"
-                  primary
-                  withArrow
-                >
-                  Goerli Faucet
-                </FaucetLink>
+              {networkAllowed && (
+                <>
+                  <Balance>
+                    <Row>
+                      <Dot
+                        className="mr10"
+                        success={!lowBalance}
+                        error={lowBalance}
+                      />
+                      <Heading level={3} size="small" color="blueDark">
+                        <FormattedMessage defaultMessage="Balance" />
+                      </Heading>
+                    </Row>
+                    <StatusText className="mt10">{status}</StatusText>
+                  </Balance>
+                  <div>
+                    {networkAllowed && lowBalance && (
+                      <>
+                        <FormattedMessage
+                          defaultMessage="You do not have enough {eth} in this account for
+                          {depositKeys} {validator}"
+                          values={{
+                            depositKeys: (
+                              <span>
+                                {depositKeys.length}
+                                {depositKeys.length > 1 ? 's' : ''}
+                              </span>
+                            ),
+                            eth: <span>{TICKER_NAME}</span>,
+                            validator: (
+                              <span>
+                                validator{depositKeys.length > 1 ? 's' : ''}
+                              </span>
+                            ),
+                          }}
+                        />
+                      </>
+                    )}
+                    {!IS_MAINNET && lowBalance && (
+                      <FaucetLink
+                        to="https://faucet.goerli.mudit.blog/"
+                        primary
+                      >
+                        <FormattedMessage
+                          defaultMessage="Get {eth}"
+                          values={{
+                            eth: <span>{TICKER_NAME}</span>,
+                          }}
+                        />
+                      </FaucetLink>
+                    )}
+                  </div>
+                </>
               )}
             </Paper>
           </Animated>
@@ -340,16 +422,23 @@ const _ConnectWalletPage = ({
       </Container>
 
       {error && error instanceof NoEthereumProviderError && (
-        <div className="flex center mt20">Please install MetaMask.</div>
+        <MetaMaskError>
+          <Text className="mb30">
+            <FormattedMessage defaultMessage="We can't detect MetaMask. Switch browsers or install MetaMask." />
+          </Text>
+          <Link to="https://metamask.io/">
+            <Button className="mr10" label="Download MetaMask" />
+          </Link>
+        </MetaMaskError>
       )}
 
       {isInvalidNetwork && (
         <div className="flex center mt20">
-          The selected network is not supported.
+          <FormattedMessage defaultMessage="Your chosen network is not supported." />
         </div>
       )}
 
-      <div className="flex center p30 mt20">
+      <ButtonRow>
         {!walletConnected && (
           <Link to={routesEnum.uploadValidatorPage}>
             <Button className="mr10" width={100} label="Back" />
@@ -368,11 +457,16 @@ const _ConnectWalletPage = ({
           <Button
             width={300}
             rainbow
-            disabled={!walletProvider || !walletConnected || !networkAllowed}
+            disabled={
+              !walletProvider ||
+              !walletConnected ||
+              !networkAllowed ||
+              lowBalance
+            }
             label="Continue"
           />
         </Link>
-      </div>
+      </ButtonRow>
     </WorkflowPageTemplate>
   );
 };


### PR DESCRIPTION
This step focusses on the user choosing a wallet and getting feedback from the app whether they're on the correct network and they have the required balance for the number of validators they want to run.

Problems fixed:
- previous design relied on color to indicate whether the network was correct. This is inaccessible so added an icon to show status.
- it was confusing that the dot would display green (to demo that the network was correct) even if you couldn't proceed because of an insufficient balance. This is now split into two separate checks.
- Added error messages inline to wallet balance and network statuses
- disabled the continue step if balance is insufficient (I assume this was accidentally left out before – please correct me if this is incorrect)

Todo:
- [ ] format status message for translations
- [ ] format button copy for translations