### PR TITLE
Key management overview step trimming

### DIFF
--- a/src/pages/Acknowledgements/index.tsx
+++ b/src/pages/Acknowledgements/index.tsx
@@ -24,6 +24,7 @@ import {
   updateAcknowledgementState,
 } from '../../store/actions/acknowledgementActions';
 import { Paper } from '../../components/Paper';
+import { FormattedMessage } from 'react-intl';
 
 interface OwnProps {}
 interface StateProps {
@@ -97,7 +98,7 @@ const _AcknowledgementPage = ({
   return (
     <WorkflowPageTemplate title="Before you deposit">
       <Subtitle>
-        Everything you should understand before becoming a validator today.
+        <FormattedMessage defaultMessage="Everything you should understand before becoming a validator today." />
       </Subtitle>
       <Paper className="flex flex-row">
         <AcknowledgementProgressTracker

--- a/src/pages/Acknowledgements/pageContent.tsx
+++ b/src/pages/Acknowledgements/pageContent.tsx
@@ -155,33 +155,10 @@ export const pageContent = {
         </Text>
         <Text size="medium" className="mt20">
           <FormattedMessage
-            defaultMessage="Your validator keys are derived from a unique mnemonic (or seed). Your
-              mnemonic/seed will be the ONLY WAY to withdraw your funds. Above all, keep it safe! No
-              one can help you if you lose this phrase."
-          />
-        </Text>
-        <Text size="medium" className="mt20">
-          <FormattedMessage
-            defaultMessage="We'll help you create keys for each of your validators. These keys
-              will be saved in password-encrypted keystore files and you will need to give these
-              to your validator software to begin validating*. You will also receive a deposit file
-              to upload to this website with the public keys for your validator."
-          />
-        </Text>
-        <Text size="medium" className="mt20">
-          <FormattedMessage
-            defaultMessage="*Warning: Do not store keys on multiple/backup validators at once {readMore}"
-            values={{
-              readMore: (
-                <Link
-                  className="my10"
-                  primary
-                  to="https://medium.com/prysmatic-labs/eth2-slashing-prevention-tips-f6faa5025f50"
-                >
-                  <FormattedMessage defaultMessage="More on slashing prevention" />
-                </Link>
-              ),
-            }}
+            defaultMessage="We'll help you create keys for every validator you want to run. They'll be generated
+              via a mnemonic (seed) which you need to keep safe. Your mnemonic will be the ONLY way to
+              withdraw your ETH when the time comes and no one can help you recover your mnemonic if
+              you lose it."
           />
         </Text>
       </>

--- a/src/pages/Acknowledgements/pageContent.tsx
+++ b/src/pages/Acknowledgements/pageContent.tsx
@@ -147,12 +147,17 @@ export const pageContent = {
     content: (
       <>
         <Text size="medium" className="mt10">
-          <FormattedMessage defaultMessage="To become a validator you'll need to know about managing keys." />
+          <FormattedMessage
+            defaultMessage="To become a validator you'll need to know about managing keys and
+              protecting a mnemonic. If you are not yet familiar with keys and mnemomics, please
+              do not proceed."
+          />
         </Text>
         <Text size="medium" className="mt20">
           <FormattedMessage
-            defaultMessage="Your validator keys are derived from a uniquemnemonic (or seed). Your
-              seed will be the ONLY WAY to withdraw your funds. Above all, keep it safe!"
+            defaultMessage="Your validator keys are derived from a unique mnemonic (or seed). Your
+              mnemonic/seed will be the ONLY WAY to withdraw your funds. Above all, keep it safe! No
+              one can help you if you lose this phrase."
           />
         </Text>
         <Text size="medium" className="mt20">
@@ -165,13 +170,7 @@ export const pageContent = {
         </Text>
         <Text size="medium" className="mt20">
           <FormattedMessage
-            defaultMessage="If you're unfamiliar with keys and mnemomics, please don't proceed. Your
-              keys will be your responsibility and no one can help you if you lose them."
-          />
-        </Text>
-        <Text size="medium" className="mt20">
-          <FormattedMessage
-            defaultMessage="*Warning: Do not store keys on multiple/backup validators at once. {readMore}"
+            defaultMessage="*Warning: Do not store keys on multiple/backup validators at once {readMore}"
             values={{
               readMore: (
                 <Link

--- a/src/pages/GenerateKeys/index.tsx
+++ b/src/pages/GenerateKeys/index.tsx
@@ -4,6 +4,7 @@ import { connect } from 'react-redux';
 import styled from 'styled-components';
 import BigNumber from 'bignumber.js';
 import { CheckBox } from 'grommet';
+import { FormattedMessage, useIntl } from 'react-intl';
 import { WorkflowPageTemplate } from '../../components/WorkflowPage/WorkflowPageTemplate';
 import { Paper } from '../../components/Paper';
 import { OperatingSystemButtons } from './OperatingSystemButtons';
@@ -25,7 +26,6 @@ import {
 import { PRICE_PER_VALIDATOR, TICKER_NAME } from '../../utils/envVars';
 import instructions1 from '../../static/instructions_1.svg';
 import instructions2 from '../../static/instructions_2.svg';
-import { FormattedMessage } from 'react-intl';
 
 export enum operatingSystem {
   'MAC',
@@ -65,6 +65,7 @@ const _GenerateKeysPage = ({
   dispatchWorkflowUpdate,
   workflow,
 }: Props): JSX.Element => {
+  const { formatMessage } = useIntl();
   const [validatorCount, setValidatorCount] = useState<number | string>(0);
   const [
     mnemonicAcknowledgementChecked,
@@ -89,14 +90,18 @@ const _GenerateKeysPage = ({
   }
 
   return (
-    <WorkflowPageTemplate title="Generate key pairs">
+    <WorkflowPageTemplate
+      title={formatMessage({ defaultMessage: 'Generate key pairs' })}
+    >
       <Paper>
         <Heading level={2} size="small" color="blueDark">
-          How many validators would you like to run?
+          <FormattedMessage defaultMessage="How many validators would you like to run?" />
         </Heading>
         <div className="flex mt20">
           <div>
-            <Text className="mb5">Validators</Text>
+            <Text className="mb5">
+              <FormattedMessage defaultMessage="Validators" />
+            </Text>
             <NumberInput value={validatorCount} setValue={setValidatorCount} />
           </div>
           <div className="ml50">
@@ -115,12 +120,14 @@ const _GenerateKeysPage = ({
       </Paper>
       <Paper className="mt20">
         <Heading level={2} size="small" color="blueMedium">
-          What is your current operating system?
+          <FormattedMessage defaultMessage="What is your current operating system?" />
         </Heading>
         <Text className="mt20 mb40">
-          Choose the OS of the computer you're currently using. This will be the
-          computer you use to generate your keys. It doesn't need to be the OS
-          you want to use for your node.
+          <FormattedMessage
+            defaultMessage="Choose the OS of the computer you're currently using. This will be the
+              computer you use to generate your keys. It doesn't need to be the OS
+              you want to use for your node."
+          />
         </Text>
         <OperatingSystemButtons chosenOs={chosenOs} setChosenOs={setChosenOs} />
       </Paper>
@@ -129,7 +136,7 @@ const _GenerateKeysPage = ({
 
       <Paper className="mt20">
         <Heading level={2} size="small" color="blueMedium">
-          Save the key files and get the validator file ready
+          <FormattedMessage defaultMessage="Save the key files and get the validator file ready" />
         </Heading>
         <Text className="mt20">
           <FormattedMessage
@@ -145,10 +152,12 @@ const _GenerateKeysPage = ({
           />
         </Text>
         <Alert variant="info" className="my40">
-          You should see that you have one keystore per validator. This keystore
-          contains your signing key, encrypted with your password. You can use
-          your mnemonic to generate your withdrawal key when you wish to
-          withdraw.
+          <FormattedMessage
+            defaultMessage="You should see that you have one keystore per validator. This keystore
+              contains your signing key, encrypted with your password. You can use
+              your mnemonic to generate your withdrawal key when you wish to
+              withdraw."
+          />
         </Alert>
         <InstructionImgContainer>
           <img src={instructions1} alt="" />
@@ -167,6 +176,19 @@ const _GenerateKeysPage = ({
         <InstructionImgContainer>
           <img src={instructions2} alt="" />
         </InstructionImgContainer>
+        <Alert variant="error">
+          <FormattedMessage
+            defaultMessage="Warning: Do not store keys on multiple (backup) validators at once"
+            description="Warns users to not run backup validators that have a live copy of their signing keys. Keys should only be on one validator machine at once."
+          />
+          <Link
+            className="mt10"
+            primary
+            to="https://medium.com/prysmatic-labs/eth2-slashing-prevention-tips-f6faa5025f50"
+          >
+            <FormattedMessage defaultMessage="More on slashing prevention" />
+          </Link>
+        </Alert>
       </Paper>
       <Paper className="mt20">
         <CheckBox
@@ -174,8 +196,7 @@ const _GenerateKeysPage = ({
           checked={mnemonicAcknowledgementChecked}
           label={
             <Text>
-              I am keeping my key(s) safe and have written down my mnemonic
-              phrase.
+              <FormattedMessage defaultMessage="I am keeping my key(s) safe and have written down my mnemonic phrase." />
             </Text>
           }
         />
@@ -183,14 +204,18 @@ const _GenerateKeysPage = ({
 
       <div className="flex center p30">
         <Link to={routesEnum.selectClient}>
-          <Button className="mr10" width={100} label="Back" />
+          <Button
+            className="mr10"
+            width={100}
+            label={formatMessage({ defaultMessage: 'Back' })}
+          />
         </Link>
         <Link to={routesEnum.uploadValidatorPage} onClick={handleSubmit}>
           <Button
             width={300}
             rainbow
             disabled={!mnemonicAcknowledgementChecked}
-            label="Continue"
+            label={formatMessage({ defaultMessage: 'Continue' })}
           />
         </Link>
       </div>


### PR DESCRIPTION
- Rearranged the "Key management" overview step copy to fit a little nicer and remove some redundancy. This prevents the "Continue" button from shifting downward too much during this flow.
- Also adds an instance of intl to acknowledgement index page