### PR TITLE
Trims margin on workflow nav items

### DIFF
--- a/src/components/WorkflowPage/WorkflowProgressBar.tsx
+++ b/src/components/WorkflowPage/WorkflowProgressBar.tsx
@@ -16,7 +16,7 @@ const StepContainer = styled.div`
 `;
 
 const Step = styled.div`
-  margin: 0 20px;
+  margin: 0 10px;
   text-align: center;
   color: ${(p: {
     disabled: boolean;


### PR DESCRIPTION
- Trims the horizontal margin on workflow nav items by half (20px -> 10px)
- Prevents wrapping of workflow nav item names above 1080px screen size

Bug ("Transaction" wrapping to new line):
![image](https://user-images.githubusercontent.com/54227730/107719586-6d027c00-6c8d-11eb-9d5c-43ca1d422873.png)

Fix:
![image](https://user-images.githubusercontent.com/54227730/107719637-91f6ef00-6c8d-11eb-9f0d-7b6ed47f51b1.png)
