### PR TITLE
Restores active workflow path highlighting

### DIFF
--- a/src/components/WorkflowPage/WorkflowPageTemplate.tsx
+++ b/src/components/WorkflowPage/WorkflowPageTemplate.tsx
@@ -12,6 +12,7 @@ import {
 import { routesEnum } from '../../Routes';
 import { WorkflowStep } from '../../store/actions/workflowActions';
 import { Helmet } from 'react-helmet';
+import { useIntl } from 'react-intl';
 
 const Content = styled.div`
   width: 100%;
@@ -59,13 +60,16 @@ const _WorkflowPageTemplate = ({
   description,
   history,
 }: Props): JSX.Element => {
+  const { locale } = useIntl();
   if ((window as any).mobileCheck()) {
     return <DesktopOnlyModal />;
   }
 
-  const calculatedWorkflowStep: WorkflowStep = mapPathnameToWorkflowStep(
-    history.location.pathname
-  );
+  const { pathname } = history.location;
+  const path = pathname.startsWith(`/${locale}`)
+    ? pathname.substr(`/${locale}`.length)
+    : pathname;
+  const calculatedWorkflowStep: WorkflowStep = mapPathnameToWorkflowStep(path);
 
   return (
     <Background workflowStep={calculatedWorkflowStep}>


### PR DESCRIPTION
- Intl upgrades altered the URL path being checked when deciding which active step the user is on
- This PR adds logic to check for the language locale and remove it from the path before checking it against the enumerated step names, and thus restores the conditional color formatting for the active item on the workflow nav bar. 

(@samajammin @ryancreatescopy)