### PR TITLE
Links to ethereum.org maintain users locale

### DIFF
--- a/src/components/Link.tsx
+++ b/src/components/Link.tsx
@@ -89,6 +89,14 @@ export const Link = (props: LinkProps) => {
   } = props;
   const { locale } = useIntl();
   const isExternal = to && to.includes('http');
+  // Check for ethereum.org root domain links
+  const ETHEREUM_DOT_ORG = 'ethereum.org';
+  const isEthereumDotOrg =
+    to &&
+    (to.includes(`http://${ETHEREUM_DOT_ORG}`) ||
+      to.includes(`https://${ETHEREUM_DOT_ORG}`) ||
+      to.includes(`http://www.${ETHEREUM_DOT_ORG}`) ||
+      to.includes(`https://www.${ETHEREUM_DOT_ORG}`));
   const isHash = isHashLink(to);
 
   if (isHash) {
@@ -106,10 +114,32 @@ export const Link = (props: LinkProps) => {
   }
 
   if (isExternal) {
+    let href = '';
+    if (isEthereumDotOrg) {
+      // Grab everything after "ethereum.org/"
+      const slug: string = to.substr(
+        to.indexOf(ETHEREUM_DOT_ORG) + ETHEREUM_DOT_ORG.length + 1
+      );
+      // Split path on "/" and check if index 0 matches current locale
+      const pathSplit: string[] = slug.split('/');
+      if (pathSplit[0] === locale) {
+        // Path of link already has matching language path
+        href = to;
+      } else if (supportedLanguages.includes(pathSplit[0])) {
+        // Path of link has a supported language, but does not match locale; swap it
+        href = `https://${ETHEREUM_DOT_ORG}/${locale}/${pathSplit
+          .slice(1)
+          .join('/')}`;
+      } else {
+        // Path of link does not specify a language; will insert locale
+        href = `https://${ETHEREUM_DOT_ORG}/${locale}/${slug}`;
+      }
+    }
+
     return (
       <StyledExternalLink
         className={className}
-        href={to}
+        href={href}
         primary={primary}
         target="_blank"
         inline={inline}

--- a/src/components/Link.tsx
+++ b/src/components/Link.tsx
@@ -90,13 +90,8 @@ export const Link = (props: LinkProps) => {
   const { locale } = useIntl();
   const isExternal = to && to.includes('http');
   // Check for ethereum.org root domain links
-  const ETHEREUM_DOT_ORG = 'ethereum.org';
-  const isEthereumDotOrg =
-    to &&
-    (to.includes(`http://${ETHEREUM_DOT_ORG}`) ||
-      to.includes(`https://${ETHEREUM_DOT_ORG}`) ||
-      to.includes(`http://www.${ETHEREUM_DOT_ORG}`) ||
-      to.includes(`https://www.${ETHEREUM_DOT_ORG}`));
+  const ETHEREUM_DOT_ORG = `https://ethereum.org`;
+  const isEthereumDotOrg = to && to.includes(ETHEREUM_DOT_ORG);
   const isHash = isHashLink(to);
 
   if (isHash) {
@@ -115,11 +110,13 @@ export const Link = (props: LinkProps) => {
 
   if (isExternal) {
     let href = '';
-    if (isEthereumDotOrg) {
-      // Grab everything after "ethereum.org/"
-      const slug: string = to.substr(
-        to.indexOf(ETHEREUM_DOT_ORG) + ETHEREUM_DOT_ORG.length + 1
-      );
+
+    if (to === ETHEREUM_DOT_ORG) {
+      // Path is to https://ethereum.org homepage; will append locale
+      href = `${ETHEREUM_DOT_ORG}/${locale}`;
+    } else if (isEthereumDotOrg) {
+      // Grab everything after "https://ethereum.org/"
+      const slug: string = to.substr(ETHEREUM_DOT_ORG.length + 1);
       // Split path on "/" and check if index 0 matches current locale
       const pathSplit: string[] = slug.split('/');
       if (pathSplit[0] === locale) {
@@ -127,12 +124,10 @@ export const Link = (props: LinkProps) => {
         href = to;
       } else if (supportedLanguages.includes(pathSplit[0])) {
         // Path of link has a supported language, but does not match locale; swap it
-        href = `https://${ETHEREUM_DOT_ORG}/${locale}/${pathSplit
-          .slice(1)
-          .join('/')}`;
+        href = `${ETHEREUM_DOT_ORG}/${locale}/${pathSplit.slice(1).join('/')}`;
       } else {
         // Path of link does not specify a language; will insert locale
-        href = `https://${ETHEREUM_DOT_ORG}/${locale}/${slug}`;
+        href = `${ETHEREUM_DOT_ORG}/${locale}/${slug}`;
       }
     }
 

--- a/src/pages/Landing/Upgrades/index.tsx
+++ b/src/pages/Landing/Upgrades/index.tsx
@@ -117,7 +117,7 @@ export const Upgrades = (): JSX.Element => {
               </Text>
               <Link
                 className="mt20 mb40"
-                to="https://www.ethereum.org/eth2/beacon-chain/"
+                to="https://ethereum.org/eth2/beacon-chain/"
               >
                 <FormattedMessage defaultMessage="More on the Beacon Chain" />
               </Link>
@@ -131,7 +131,7 @@ export const Upgrades = (): JSX.Element => {
               </Text>
               <Link
                 className="mt20 mb40"
-                to="https://www.ethereum.org/eth2/the-docking/"
+                to="https://ethereum.org/eth2/the-docking/"
               >
                 <FormattedMessage defaultMessage="More on the merge" />
               </Link>
@@ -141,7 +141,7 @@ export const Upgrades = (): JSX.Element => {
               </Text>
               <Link
                 className="mt20 mb40"
-                to="https://www.ethereum.org/eth2/shard-chains/"
+                to="https://ethereum.org/eth2/shard-chains/"
               >
                 <FormattedMessage defaultMessage="More on shard chains" />
               </Link>


### PR DESCRIPTION
- Added logic to check for links going to `ethereum.org` pages (no sub-domains)
- Checks if link matches users current locale / language selection
- If it does, link passes unchanged. If it doesn't match or doesn't have a language path, the users current locale is injected to the link.