### PR TITLE
Use _blank link during the acknowledgements step

### DIFF
--- a/src/pages/Acknowledgements/pageContent.tsx
+++ b/src/pages/Acknowledgements/pageContent.tsx
@@ -130,7 +130,7 @@ export const pageContent = {
         >
           <FormattedMessage defaultMessage="The Eth2 specification" />
         </Link>
-        <Link to="/faq" className="my10" primary>
+        <Link shouldOpenNewTab={true} to="/faq" className="my10" primary>
           <FormattedMessage defaultMessage="More on slashing risks" />
         </Link>
       </>
@@ -278,7 +278,13 @@ export const pageContent = {
         <Text size="medium" className="my10">
           <FormattedMessage defaultMessage="I have read and agree to the Launchpad terms of service." />
         </Text>
-        <Link inline to="/terms-of-service" className="my10" primary>
+        <Link
+          inline
+          shouldOpenNewTab={true}
+          to="/terms-of-service"
+          className="my10"
+          primary
+        >
           <FormattedMessage defaultMessage="Terms of service" />
         </Link>
       </>


### PR DESCRIPTION
### Issue

During the acknowledgements step, if the user clicks the internal link and then goes back, they will return to Step 1. For better UX, the links should be opened on new tabs.

### How did I fix it

Add `shouldOpenNewTab={true}` to these links.



