### PR TITLE
Update top up link margins

### DIFF
--- a/src/components/AppBar.tsx
+++ b/src/components/AppBar.tsx
@@ -237,7 +237,7 @@ const _AppBar = ({ location }: RouteComponentProps) => {
             <FormattedMessage defaultMessage="FAQ" />
           </BarLinkText>
         </Link>
-        <Link to={routesEnum.topUpPage} className="mx30 secondary-link">
+        <Link to={routesEnum.topUpPage} className="mx10 secondary-link">
           <BarLinkText
             level={4}
             margin="none"


### PR DESCRIPTION
Minor style tweak - unifies margin of "Top Up" nav link with the rest.

Context: we tightened the margins (https://github.com/ethereum/eth2.0-deposit/commit/1d0b6d6673e29a0279c04fdc8a36e18ba7999d92) but must have missed updating the Top Up link when we added that (https://github.com/ethereum/eth2.0-deposit/pull/291)