### PR TITLE
CLI flag translation prevention

### DIFF
--- a/src/pages/GenerateKeys/Option2.tsx
+++ b/src/pages/GenerateKeys/Option2.tsx
@@ -144,6 +144,8 @@ export const Option2 = ({
   };
 
   const renderDepositKeyCommand = () => {
+    const translateFlags = false;
+
     if (os === 'mac' || os === 'linux') {
       return (
         <Pre className="my0">
@@ -155,10 +157,14 @@ export const Option2 = ({
                   'this is used as a command line flag, short for "number of validators"',
               })} ${validatorCount}`
             : ''}{' '}
-          {`--${formatMessage({
-            defaultMessage: 'chain',
-            description: 'this is used as a command line flag',
-          })} ${ETH2_NETWORK_NAME.toLowerCase()}`}
+          {`--${
+            translateFlags
+              ? formatMessage({
+                  defaultMessage: 'chain',
+                  description: 'this is used as a command line flag',
+                })
+              : `chain`
+          } ${ETH2_NETWORK_NAME.toLowerCase()}`}
         </Pre>
       );
     }
@@ -174,10 +180,14 @@ export const Option2 = ({
                   'this is used as a command line flag, short for "number of validators"',
               })} ${validatorCount}`
             : ''}{' '}
-          {`--${formatMessage({
-            defaultMessage: 'chain',
-            description: 'this is used as a command line flag',
-          })} ${ETH2_NETWORK_NAME.toLowerCase()}`}
+          {`--${
+            translateFlags
+              ? formatMessage({
+                  defaultMessage: 'chain',
+                  description: 'this is used as a command line flag',
+                })
+              : `chain`
+          } ${ETH2_NETWORK_NAME.toLowerCase()}`}
         </Pre>
       );
     }


### PR DESCRIPTION
At this moment, the Launchpad site is ready for translations, but the translated `--chain` CLI command shown to users is currently not a live feature in the actual deposit CLI tool. 

This adds a boolean conditional to skip translating this for now, and to just leave `--chain` in English, which the deposit CLI will accept without issues. 
