### PR TITLE
Add "withdrawal credentials" section to FAQ

### DIFF
--- a/src/intl/compiled/en.json
+++ b/src/intl/compiled/en.json
@@ -485,16 +485,6 @@
       "value": "Install deposit-cli tool"
     }
   ],
-  "3Bo3k6": [
-    {
-      "type": 1,
-      "value": "withdrawalCredentials"
-    },
-    {
-      "type": 0,
-      "value": " field is the 32-byte value in the deposit, for verifying the destination of valid withdrawals. Currently, there are two types of withdrawals: BLS withdrawal and Eth1 address withdrawal."
-    }
-  ],
   "3CRtg8": [
     {
       "type": 0,
@@ -4835,6 +4825,16 @@
     {
       "type": 0,
       "value": "Note"
+    }
+  ],
+  "qPG/YN": [
+    {
+      "type": 1,
+      "value": "withdrawalCredentials"
+    },
+    {
+      "type": 0,
+      "value": " is a 32-byte field in the deposit, for verifying the destination of valid withdrawals. Currently, there are two types of withdrawals: BLS withdrawal and Eth1 address withdrawal."
     }
   ],
   "qQ+Xla": [

--- a/src/intl/compiled/en.json
+++ b/src/intl/compiled/en.json
@@ -307,6 +307,12 @@
       "value": "Earn continuous rewards for providing a public good to the community."
     }
   ],
+  "122+yR": [
+    {
+      "type": 0,
+      "value": "withdrawal key"
+    }
+  ],
   "19o6KO": [
     {
       "type": 0,
@@ -477,6 +483,16 @@
     {
       "type": 0,
       "value": "Install deposit-cli tool"
+    }
+  ],
+  "3Bo3k6": [
+    {
+      "type": 1,
+      "value": "withdrawalCredentials"
+    },
+    {
+      "type": 0,
+      "value": " field is the 32-byte value in the deposit, for verifying the destination of valid withdrawals. Currently, there are two types of withdrawals: BLS withdrawal and Eth1 address withdrawal."
     }
   ],
   "3CRtg8": [
@@ -653,6 +669,12 @@
     {
       "type": 0,
       "value": "CURRENT"
+    }
+  ],
+  "54J/qs": [
+    {
+      "type": 0,
+      "value": "What happens if I use BLS withdrawal and I lose my withdrawal key?"
     }
   ],
   "58PXVy": [
@@ -1665,6 +1687,12 @@
       "value": "Network"
     }
   ],
+  "I5lWZA": [
+    {
+      "type": 0,
+      "value": "Can I change the withdrawal credentials of my validator after the first deposit?"
+    }
+  ],
   "IAKvZ0": [
     {
       "type": 0,
@@ -2385,6 +2413,24 @@
     {
       "type": 0,
       "value": "pip documentation"
+    }
+  ],
+  "PyArfT": [
+    {
+      "type": 0,
+      "value": "Eth1 address withdrawal: If you want to withdraw to Eth1 chain after the merge, you can set "
+    },
+    {
+      "type": 1,
+      "value": "eth1AddressWithdraw"
+    },
+    {
+      "type": 0,
+      "value": " when running deposit-cli. "
+    },
+    {
+      "type": 1,
+      "value": "boldWarning"
     }
   ],
   "Q1ZwPT": [
@@ -3317,6 +3363,12 @@
       "value": "Again, it depends. Behaving maliciously – for example attesting to invalid or contradicting blocks, will lead to your stake being slashed."
     }
   ],
+  "ZPpZDC": [
+    {
+      "type": 0,
+      "value": "Please ensure that you have control over the Eth1 address."
+    }
+  ],
   "ZRbxwY": [
     {
       "type": 0,
@@ -3529,6 +3581,12 @@
     {
       "type": 0,
       "value": "How much will I be penalized for acting maliciously?"
+    }
+  ],
+  "cpxfOR": [
+    {
+      "type": 0,
+      "value": "What are withdrawal credentials?"
     }
   ],
   "cs9mQw": [
@@ -4359,6 +4417,28 @@
       "value": "Importing from Launchpad documentation"
     }
   ],
+  "ljWKM1": [
+    {
+      "type": 0,
+      "value": "BLS withdrawal: By default, deposit-cli would generate withdrawal credentials with the "
+    },
+    {
+      "type": 1,
+      "value": "boldWithdrawalKey"
+    },
+    {
+      "type": 0,
+      "value": " derived via mnemonics in "
+    },
+    {
+      "type": 1,
+      "value": "eip2334"
+    },
+    {
+      "type": 0,
+      "value": " format."
+    }
+  ],
   "ll/zMW": [
     {
       "type": 0,
@@ -4865,6 +4945,12 @@
       "value": "Given a fixed total number of validators, the rewards/penalties predominantly scale with the balance of the validator – attesting with a higher balance results in larger rewards/penalties whereas attesting with a lower balance results in lower rewards/penalties."
     }
   ],
+  "rnDgcN": [
+    {
+      "type": 0,
+      "value": "No, you cannot change your withdrawal credentials in top-ups."
+    }
+  ],
   "rs4eqr": [
     {
       "type": 0,
@@ -5163,6 +5249,12 @@
       "value": "Your balance is updated periodically by the Ethereum network rules as you carry (or fail to carry) out your responsibilities."
     }
   ],
+  "vCHTnu": [
+    {
+      "type": 0,
+      "value": "Withdrawal credentials"
+    }
+  ],
   "vEJDo8": [
     {
       "type": 0,
@@ -5337,12 +5429,6 @@
     {
       "type": 0,
       "value": "I am an early adopter, and I accept that software and design bugs may result in me being slashed."
-    }
-  ],
-  "xJPCw/": [
-    {
-      "type": 0,
-      "value": "What happens if I lose my withdrawal key?"
     }
   ],
   "xOSMb1": [

--- a/src/intl/en.json
+++ b/src/intl/en.json
@@ -114,6 +114,9 @@
   "0uqjBl": {
     "message": "Earn continuous rewards for providing a public good to the community."
   },
+  "122+yR": {
+    "message": "withdrawal key"
+  },
   "19o6KO": {
     "message": "When can I withdraw my funds, and what’s the difference between exiting and withdrawing?"
   },
@@ -183,6 +186,9 @@
   "38VH2G": {
     "message": "Install deposit-cli tool"
   },
+  "3Bo3k6": {
+    "message": "{withdrawalCredentials} field is the 32-byte value in the deposit, for verifying the destination of valid withdrawals. Currently, there are two types of withdrawals: BLS withdrawal and Eth1 address withdrawal."
+  },
   "3CRtg8": {
     "message": "You do not have enough {eth} in this account for {numberOfValidators} {validator}"
   },
@@ -244,6 +250,9 @@
   },
   "52qGy6": {
     "message": "CURRENT"
+  },
+  "54J/qs": {
+    "message": "What happens if I use BLS withdrawal and I lose my withdrawal key?"
   },
   "58PXVy": {
     "message": "Why two keys instead of one?"
@@ -661,6 +670,9 @@
   "I3JhPS": {
     "message": "Network"
   },
+  "I5lWZA": {
+    "message": "Can I change the withdrawal credentials of my validator after the first deposit?"
+  },
   "IAKvZ0": {
     "message": "The Eth2 upgrades"
   },
@@ -949,6 +961,9 @@
   },
   "Px7wWb": {
     "message": "pip documentation"
+  },
+  "PyArfT": {
+    "message": "Eth1 address withdrawal: If you want to withdraw to Eth1 chain after the merge, you can set {eth1AddressWithdraw} when running deposit-cli. {boldWarning}"
   },
   "Q1ZwPT": {
     "message": "clipboard"
@@ -1282,6 +1297,9 @@
   "ZPRDyW": {
     "message": "Again, it depends. Behaving maliciously – for example attesting to invalid or contradicting blocks, will lead to your stake being slashed."
   },
+  "ZPpZDC": {
+    "message": "Please ensure that you have control over the Eth1 address."
+  },
   "ZRbxwY": {
     "message": "Eth2 validator checklist"
   },
@@ -1380,6 +1398,9 @@
   },
   "clxIWO": {
     "message": "How much will I be penalized for acting maliciously?"
+  },
+  "cpxfOR": {
+    "message": "What are withdrawal credentials?"
   },
   "cs9mQw": {
     "message": "Learn more about the roles and responsibilities of Eth2 validators."
@@ -1709,6 +1730,9 @@
   "lfV1bj": {
     "message": "Importing from Launchpad documentation"
   },
+  "ljWKM1": {
+    "message": "BLS withdrawal: By default, deposit-cli would generate withdrawal credentials with the {boldWithdrawalKey} derived via mnemonics in {eip2334} format."
+  },
   "ll/zMW": {
     "message": "This is a non-reversible transaction."
   },
@@ -1920,6 +1944,9 @@
   "rcdxTW": {
     "message": "Given a fixed total number of validators, the rewards/penalties predominantly scale with the balance of the validator – attesting with a higher balance results in larger rewards/penalties whereas attesting with a lower balance results in lower rewards/penalties."
   },
+  "rnDgcN": {
+    "message": "No, you cannot change your withdrawal credentials in top-ups."
+  },
   "rs4eqr": {
     "message": "You may need to top up your validator's balance for two important reasons. If your validator's effective balance is below {PRICE_PER_VALIDATOR} {TICKER_NAME} you won't be earning your full staker rewards. And if it drops as low as {EJECTION_PRICE} {TICKER_NAME} the system will eject your validator."
   },
@@ -2018,6 +2045,9 @@
   "vBOf5K": {
     "message": "Your balance is updated periodically by the Ethereum network rules as you carry (or fail to carry) out your responsibilities."
   },
+  "vCHTnu": {
+    "message": "Withdrawal credentials"
+  },
   "vEJDo8": {
     "message": "Protect your funds using monitoring software, and learn how to handle different real world scenarios."
   },
@@ -2093,9 +2123,6 @@
   },
   "xH5GKj": {
     "message": "I am an early adopter, and I accept that software and design bugs may result in me being slashed."
-  },
-  "xJPCw/": {
-    "message": "What happens if I lose my withdrawal key?"
   },
   "xOSMb1": {
     "description": "Links to the documentation for the eth1 client Nethermind, specifically for testnet Goerli",

--- a/src/intl/en.json
+++ b/src/intl/en.json
@@ -186,9 +186,6 @@
   "38VH2G": {
     "message": "Install deposit-cli tool"
   },
-  "3Bo3k6": {
-    "message": "{withdrawalCredentials} field is the 32-byte value in the deposit, for verifying the destination of valid withdrawals. Currently, there are two types of withdrawals: BLS withdrawal and Eth1 address withdrawal."
-  },
   "3CRtg8": {
     "message": "You do not have enough {eth} in this account for {numberOfValidators} {validator}"
   },
@@ -1889,6 +1886,9 @@
   },
   "qMePPG": {
     "message": "Note"
+  },
+  "qPG/YN": {
+    "message": "{withdrawalCredentials} is a 32-byte field in the deposit, for verifying the destination of valid withdrawals. Currently, there are two types of withdrawals: BLS withdrawal and Eth1 address withdrawal."
   },
   "qQ+Xla": {
     "message": "Korean"

--- a/src/pages/FAQ/index.jsx
+++ b/src/pages/FAQ/index.jsx
@@ -583,7 +583,7 @@ export const FAQ = () => {
             </Heading>
             <Text className="mt10">
               <FormattedMessage
-                defaultMessage="{withdrawalCredentials} field is the 32-byte value in the deposit, for verifying the
+                defaultMessage="{withdrawalCredentials} is a 32-byte field in the deposit, for verifying the
                   destination of valid withdrawals. Currently, there are two types of
                   withdrawals: BLS withdrawal and Eth1 address withdrawal."
                 values={{
@@ -593,7 +593,7 @@ export const FAQ = () => {
                       inline
                       to="https://github.com/ethereum/eth2.0-specs/blob/master/specs/phase0/validator.md#withdrawal-credentials"
                     >
-                      Withdrawal credentials
+                      Withdrawal Credentials
                     </Link>
                   ),
                 }}

--- a/src/pages/FAQ/index.jsx
+++ b/src/pages/FAQ/index.jsx
@@ -572,6 +572,94 @@ export const FAQ = () => {
           </section>
         </section>
         <section>
+          <Anchor to="#withdrawal-credentials" id="withdrawal-credentials">
+            <SectionTitle level={3}>
+              <FormattedMessage defaultMessage="Withdrawal credentials" />
+            </SectionTitle>
+          </Anchor>
+          <section>
+            <Heading level={4}>
+              <FormattedMessage defaultMessage="What are withdrawal credentials?" />
+            </Heading>
+            <Text className="mt10">
+              <FormattedMessage
+                defaultMessage="{withdrawalCredentials} field is the 32-byte value in the deposit, for verifying the
+                  destination of valid withdrawals. Currently, there are two types of
+                  withdrawals: BLS withdrawal and Eth1 address withdrawal."
+                values={{
+                  withdrawalCredentials: (
+                    <Link
+                      primary
+                      inline
+                      to="https://github.com/ethereum/eth2.0-specs/blob/master/specs/phase0/validator.md#withdrawal-credentials"
+                    >
+                      Withdrawal credentials
+                    </Link>
+                  ),
+                }}
+              />
+            </Text>
+            <ol>
+              <li>
+                <Text className="mt10">
+                  <FormattedMessage
+                    defaultMessage="BLS withdrawal: By default, deposit-cli would generate withdrawal credentials with the {boldWithdrawalKey} derived via mnemonics in {eip2334} format."
+                    values={{
+                      boldWithdrawalKey: (
+                        <strong>
+                          {formatMessage({
+                            defaultMessage: 'withdrawal key',
+                          })}
+                        </strong>
+                      ),
+                      eip2334: (
+                        <Link
+                          primary
+                          inline
+                          to="https://eips.ethereum.org/EIPS/eip-2334"
+                        >
+                          EIP2334
+                        </Link>
+                      ),
+                    }}
+                  />
+                </Text>
+              </li>
+              <li>
+                <Text className="mt10">
+                  <FormattedMessage
+                    defaultMessage="Eth1 address withdrawal: If you want to withdraw to Eth1 chain after the merge, you can set {eth1AddressWithdraw} when running deposit-cli. {boldWarning}"
+                    values={{
+                      eth1AddressWithdraw: (
+                        <code>
+                          {' '}
+                          {`--eth1_withdrawal_address <YOUR ETH1 ADDRESS>`}{' '}
+                        </code>
+                      ),
+                      boldWarning: (
+                        <strong>
+                          {formatMessage({
+                            defaultMessage:
+                              'Please ensure that you have control over the Eth1 address.',
+                          })}
+                        </strong>
+                      ),
+                    }}
+                  />
+                </Text>
+              </li>
+            </ol>
+            <section>
+              <Heading level={4}>
+                <FormattedMessage defaultMessage="Can I change the withdrawal credentials of my validator after the first deposit?" />
+              </Heading>
+              <Text className="mt10">
+                <FormattedMessage defaultMessage="No, you cannot change your withdrawal credentials in top-ups." />
+              </Text>
+            </section>
+          </section>
+        </section>
+        <section>
           <Anchor to="#keys" id="keys">
             <SectionTitle level={3}>
               <FormattedMessage defaultMessage="Keys" />
@@ -639,7 +727,7 @@ export const FAQ = () => {
           </section>
           <section>
             <Heading level={4}>
-              <FormattedMessage defaultMessage="What happens if I lose my withdrawal key?" />
+              <FormattedMessage defaultMessage="What happens if I use BLS withdrawal and I lose my withdrawal key?" />
             </Heading>
             <Text className="mt10">
               <FormattedMessage


### PR DESCRIPTION
In that next deposit-cli release, https://github.com/ethereum/eth2.0-deposit-cli/pull/195 will introduce a new withdrawal credentials format - Eth1 address withdrawal. This PR adds some description about what are withdrawal credentials and this new feature.

Note that do not merge this PR before the next deposit-cli release.
